### PR TITLE
Move returnArray back into StatementController

### DIFF
--- a/app/controllers/xapi/BaseController.php
+++ b/app/controllers/xapi/BaseController.php
@@ -32,31 +32,6 @@ class BaseController extends Controller {
         $this->lrs = $lrs;
     }
 
-	public function returnArray( $statements=array(), $params=array() ){
-
-        $array = array(
-            'X-Experience-API-Version'   =>  \Config::get('xapi.using_version'),
-            'route'     =>  \Request::path()
-        );
-
-        $array['params'] = $params;
-
-        //replace replace &46; in keys with . 
-        //see https://github.com/LearningLocker/LearningLocker/wiki/A-few-quirks for more info
-        if( !empty($statements) ){
-        	foreach( $statements as &$s ){
-        		$s = \app\locker\helpers\Helpers::replaceHtmlEntity( $s );
-        	}
-        }
-        
-        $array['statements'] = $statements;
-
-        $array['more'] = '';//if more results available, provide link to access them
-
-        return \Response::make( $array, 200 );
-        
-    }
-
 
     /**
      * Get all of the input and files for the request and store them in params.

--- a/app/controllers/xapi/StatementController.php
+++ b/app/controllers/xapi/StatementController.php
@@ -117,4 +117,29 @@ class StatementsController extends BaseController {
 
 	}
 
+	public function returnArray( $statements=array(), $params=array() ){
+
+        $array = array(
+            'X-Experience-API-Version'   =>  \Config::get('xapi.using_version'),
+            'route'     =>  \Request::path()
+        );
+
+        $array['params'] = $params;
+
+        //replace replace &46; in keys with . 
+        //see https://github.com/LearningLocker/LearningLocker/wiki/A-few-quirks for more info
+        if( !empty($statements) ){
+        	foreach( $statements as &$s ){
+        		$s = \app\locker\helpers\Helpers::replaceHtmlEntity( $s );
+        	}
+        }
+        
+        $array['statements'] = $statements;
+
+        $array['more'] = '';//if more results available, provide link to access them
+
+        return \Response::make( $array, 200 );
+        
+    }
+
 }


### PR DESCRIPTION
This method is statement specific, as such it doesn't belong in Controllers\xAPI\BaseController
