### PR TITLE
Fix wrong condition checking in EloquentStatementRepository::doesStatementIdExist()

### DIFF
--- a/app/locker/repository/Statement/EloquentStatementRepository.php
+++ b/app/locker/repository/Statement/EloquentStatementRepository.php
@@ -443,11 +443,19 @@ class EloquentStatementRepository implements StatementRepository {
               ->where('statement.id', $id)
               ->first();
     
-    if( $exists ){
-      if( array_multisort( $exists->toArray() ) === array_multisort( $statement ) ){
-        return 'conflict-matches';
-      }
-      return 'conflict-nomatch';
+    if ($exists) {
+        $saved_statement = (array)$exists['statement'];
+        unset($saved_statement['stored']);
+        array_multisort($saved_statement);
+        array_multisort($statement);
+        ksort($saved_statement);
+        ksort($statement);
+    
+        if ($saved_statement == $statement) {
+            return 'conflict-matches';
+        }
+    
+        return 'conflict-nomatch';
     }
 
     return false;


### PR DESCRIPTION
array_multisort($array) alter to $array, not return new array. This condition checking is not correct.
