### PR TITLE
Reporting grouping typeahead fix and composer.lock added to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /bootstrap/compiled.php
 /vendor
 composer.phar
+composer.lock
 .DS_Store
 Thumbs.db
 


### PR DESCRIPTION
The first part of this reporting.js change removes duplicate entries for groupings that mongo may return.

The second part changes what we return to the typeahead by including a name if possible.
