### PR TITLE
Fix to more link and totals (issue #275)

### DIFF
--- a/app/controllers/xapi/StatementController.php
+++ b/app/controllers/xapi/StatementController.php
@@ -264,7 +264,7 @@ class StatementsController extends BaseController {
           $url = $url . '&offset=' . $offset;
         }
       }else{
-        if( isset($this->params) ){
+        if( sizeof($this->params) > 0 ){
           $url = $url . '&offset=' . $offset;
         }else{
           $url = $url . '?offset=' . $offset;

--- a/app/locker/repository/Statement/EloquentStatementRepository.php
+++ b/app/locker/repository/Statement/EloquentStatementRepository.php
@@ -32,11 +32,18 @@ class EloquentStatementRepository implements StatementRepository {
    * Count statements for any give lrs
    *
    * @param string Lrs
+   * @param array parameters Any parameters for filtering
    * @return count
    *
    **/
-  public function count( $lrs ){
-    return $this->statement->where('lrs._id', $lrs)->remember(5)->count();
+  public function count( $lrs, $parameters=null ){
+    $query = $this->statement->where('lrs._id', $lrs);
+
+    if( !is_null($parameters)){
+      $this->addParameters( $query, $parameters, true );
+    }
+
+    return $query->remember(5)->count();
   }
 
   /**
@@ -272,7 +279,7 @@ class EloquentStatementRepository implements StatementRepository {
    * @param array  $parameters The parameters to add
    *
    */
-  private function addParameters( $statements, $parameters ){
+  private function addParameters( $statements, $parameters, $count=false ){
 
     //Check if agent has been passed
     if( isset($parameters['agent']) ){
@@ -341,28 +348,29 @@ class EloquentStatementRepository implements StatementRepository {
     }
 
     //@todo attachments
+    if(!$count){
+      $server_statement_limit = 100;
 
-    $server_statement_limit = 100;
-
-    if( isset( $parameters['limit'] ) ){
-      $limit = intval($parameters['limit']);
-      if( $limit === 0 ){
-        $statements->take( $server_statement_limit ); //server set limit
+      if( isset( $parameters['limit'] ) ){
+        $limit = intval($parameters['limit']);
+        if( $limit === 0 ){
+          $statements->take( $server_statement_limit ); //server set limit
+        } else {
+          $statements->take( $limit );
+        }
       } else {
-        $statements->take( $limit );
+        $statements->take( $server_statement_limit );
       }
-    } else {
-      $statements->take( $server_statement_limit );
-    }
-         
-    if( isset( $parameters['offset'] ) ){
-      $statements->skip( $parameters['offset'] );
-    }
+           
+      if( isset( $parameters['offset'] ) ){
+        $statements->skip( $parameters['offset'] );
+      }
 
-    if( isset( $parameters['ascending'] ) && $parameters['ascending'] == 'true' ){
-      $statements->orderBy('statement.stored', 'asc');
-    }else{
-      $statements->orderBy('statement.stored', 'desc');
+      if( isset( $parameters['ascending'] ) && $parameters['ascending'] == 'true' ){
+        $statements->orderBy('statement.stored', 'asc');
+      }else{
+        $statements->orderBy('statement.stored', 'desc');
+      }
     }
 
     return $statements;


### PR DESCRIPTION
The params were always 'set', but were simply a blank array when empty. Using `sizeof` instead to check for params sent before constructing the more link.

The total sent back in each request was ignoring parameters passed; the more link was also only generated based off this total value.
