### PR TITLE
Removes dev-master to avoid problems.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     }
   ],
   "require": {
-    "laravel/framework": "4.2.x",
+    "laravel/framework": "4.2.8",
     "jenssegers/mongodb": "1.4.x",
     "davejamesmiller/laravel-breadcrumbs": "2.2.x",
     "way/generators": "2.6.x",


### PR DESCRIPTION
Identified in [Travis build](https://travis-ci.org/LearningLocker/learninglocker/builds/35340186). This pull request restricts the version of [laravel/framework](https://github.com/laravel/framework/compare/v4.2.8...v4.2.9) for now until the [issue in jenssegers/laravel-mongodb](https://github.com/jenssegers/laravel-mongodb/issues/321) is resolved.
