### PR TITLE
#483 Add --allow-root to Bower

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,13 +67,13 @@
     "post-install-cmd": [
       "php artisan optimize",
       "php artisan js-localization:refresh",
-      "cd public/assets/js && bower update && cd ../../.."
+      "cd public/assets/js && bower --allow-root update && cd ../../.."
     ],
     "post-update-cmd": [
       "php artisan clear-compiled",
       "php artisan optimize",
       "php artisan js-localization:refresh",
-      "cd public/assets/js && bower update && cd ../../.."
+      "cd public/assets/js && bower --allow-root update && cd ../../.."
     ],
     "post-create-project-cmd": [
       "php artisan key:generate"


### PR DESCRIPTION
`composer install` fails while executing via root. Modified composer.json to allow root.