### PR TITLE
Adds migration for reference arrays.

### DIFF
--- a/app/database/migrations/2015_03_26_164005_statement_ref_array.php
+++ b/app/database/migrations/2015_03_26_164005_statement_ref_array.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class StatementRefArray extends Migration {
+	public function up() {
+    Statement::chunk(1000, function($statements) {
+      foreach ($statements as $statement) {
+        if (is_object($statement->refs) || (is_array($statement->refs) && isset($statement->refs['id']))) {
+          $statement->refs = [$statement->refs];
+          $statement->save();
+        }
+      }
+      echo(count($statements) . ' converted.');
+    });
+
+    echo('All finished, hopefully!');
+  }
+
+  public function down() {
+    echo('Nothing to do.');
+  }
+}


### PR DESCRIPTION
This fixes a bug in which the object was stored as the refs rather than an array of objects.