### PR TITLE
Run the refresh out of independent shell script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,26 +66,14 @@
   },
   "scripts": {
     "post-install-cmd": [
-      "php composer.phar refresh"
+      "refresh.sh"
     ],
     "post-update-cmd": [
       "php artisan clear-compiled",
-      "php composer.phar refresh"
+      "refresh.sh"
     ],
     "post-create-project-cmd": [
       "php artisan key:generate"
-    ],
-    "refresh": [
-      "php artisan optimize",
-      "php artisan js-localization:refresh",
-      "php composer.phar clean-bower"
-    ],
-    "clean-bower": [
-      "find public/assets/js/bower_components/ -type f -name '*.md' | xargs rm -f",
-      "find public/assets/js/bower_components/ -type d -name 'docs' | xargs rm -rf",
-      "find public/assets/js/bower_components/ -type d -name 'spec' | xargs rm -rf",
-      "find public/assets/js/bower_components/ -type d -name 'test' | xargs rm -rf",
-      "find public/assets/js/bower_components/ -type f -not \\( -name '*.css' -o -name '*.js' \\) | xargs rm -rf"
     ]
   },
   "minimum-stability": "stable"

--- a/composer.json
+++ b/composer.json
@@ -66,11 +66,11 @@
   },
   "scripts": {
     "post-install-cmd": [
-      "refresh.sh"
+      "sh refresh.sh"
     ],
     "post-update-cmd": [
       "php artisan clear-compiled",
-      "refresh.sh"
+      "sh refresh.sh"
     ],
     "post-create-project-cmd": [
       "php artisan key:generate"

--- a/refresh.sh
+++ b/refresh.sh
@@ -1,0 +1,11 @@
+echo "Refreshing LL files"
+php artisan optimize
+php artisan js-localization:refresh
+
+echo "Cleaning bower_components"
+find public/assets/js/bower_components/ -type f -name '*.md' | xargs rm -f
+find public/assets/js/bower_components/ -type d -name 'docs' | xargs rm -rf
+find public/assets/js/bower_components/ -type d -name 'spec' | xargs rm -rf
+find public/assets/js/bower_components/ -type d -name 'test' | xargs rm -rf
+find public/assets/js/bower_components/ -type f -not \( -name '*.css' -o -name '*.js' \) -print
+find public/assets/js/bower_components/ -type f -not \( -name '*.css' -o -name '*.js' \) | xargs rm -rf


### PR DESCRIPTION
Removes explicit dependency for composer.phar from the composer.json for developers not wishing to keep a separate instance of composer updated. Also mitigates some issues seen when running `xargs` commands through Bash on Windows environments.