### PR TITLE
Adds insert API.

### DIFF
--- a/app/controllers/api/Statements.php
+++ b/app/controllers/api/Statements.php
@@ -68,6 +68,10 @@ class Statements extends Base {
     return $this->returnJson($data);
   }
 
+  /**
+   * Inserts new statements based on existing ones in one query using our existing aggregation.
+   * @return Json<[String]> Ids of the inserted statements.
+   */
   public function insert() {
     $pipeline = $this->getParam('pipeline');
     return \Response::json($this->query->insert($pipeline, $this->getOptions()));

--- a/app/controllers/api/Statements.php
+++ b/app/controllers/api/Statements.php
@@ -68,6 +68,11 @@ class Statements extends Base {
     return $this->returnJson($data);
   }
 
+  public function insert() {
+    $pipeline = $this->getParam('pipeline');
+    return \Response::json($this->query->insert($pipeline, $this->getOptions()));
+  }
+
   public function void() {
     $match = $this->getParam('match');
     return \Response::json($this->query->void($match, $this->getOptions()));

--- a/app/locker/repository/Query/EloquentQueryRepository.php
+++ b/app/locker/repository/Query/EloquentQueryRepository.php
@@ -124,8 +124,14 @@ class EloquentQueryRepository implements QueryRepository {
     ]]);
   }
 
-  public function insert(array $project, array $opts) {
-    $statements = $this->aggregate($opts['lrs_id'], $project)['result'];
+  /**
+   * Inserts new statements based on existing ones in one query using our existing aggregation.
+   * @param [Mixed] $pipeline
+   * @param [Sting => Mixed] $opts
+   * @return [String] Ids of the inserted statements.
+   */
+  public function insert(array $pipeline, array $opts) {
+    $statements = $this->aggregate($opts['lrs_id'], $pipeline)['result'];
 
     if (count($statements) > 0) {
       $opts['authority'] = json_decode(json_encode($opts['client']['authority']));

--- a/app/locker/repository/Query/EloquentQueryRepository.php
+++ b/app/locker/repository/Query/EloquentQueryRepository.php
@@ -124,6 +124,17 @@ class EloquentQueryRepository implements QueryRepository {
     ]]);
   }
 
+  public function insert(array $project, array $opts) {
+    $statements = $this->aggregate($opts['lrs_id'], $project)['result'];
+
+    if (count($statements) > 0) {
+      $opts['authority'] = json_decode(json_encode($opts['client']['authority']));
+      return (new StatementsRepo())->store(json_decode(json_encode($statements)), [], $opts);
+    } else {
+      return [];
+    }
+  }
+
   public function void(array $match, array $opts) {
     $void_id = 'http://adlnet.gov/expapi/verbs/voided';
     $match = [

--- a/app/routes.php
+++ b/app/routes.php
@@ -390,6 +390,7 @@ Route::group( array('prefix' => 'data/xAPI', 'before'=>'auth.statement'), functi
 });
 
 Route::group(['prefix' => 'api/v2', 'before' => 'auth.statement'], function () {
+  Route::get('statements/insert', ['uses' => 'Controllers\API\Statements@insert']);
   Route::get('statements/void', ['uses' => 'Controllers\API\Statements@void']);
 });
 


### PR DESCRIPTION
An API to insert new statements based on existing ones in one query using our existing aggregation.

Example pipeline for voiding unvoided and non voiding statements.
```
[{
  "$match": {
    "statement.verb.id": {"$ne": "http://adlnet.gov/expapi/verbs/voided"},
    "voided": false
  }
}, {
  "$project": {
    "_id": 0,
    "actor": {
      "name": {"$literal": "Darth Voider"},
      "mbox": {"$literal": "mailto:darth@voider.com"}
    },
    "verb": {
      "id": {"$literal": "http://adlnet.gov/expapi/verbs/voided"},
      "display": {
        "en": {"$literal": "voided"}
      }
    },
    "object": {
      "objectType": {"$literal": "StatementRef"},
      "id": "$statement.id"
    }
  }
}]
```