### PR TITLE
Fixes language issues

### DIFF
--- a/app/controllers/LrsController.php
+++ b/app/controllers/LrsController.php
@@ -191,7 +191,6 @@ class LrsController extends BaseController {
    */
   public function statements($lrs_id){
     $site = \Site::first();
-
     $statements = (new StatementIndexer)->index(new IndexOptions([
       'lrs_id' => $lrs_id,
       'limit' => $this->statement->count([
@@ -200,7 +199,6 @@ class LrsController extends BaseController {
       ]),
       'scopes' => ['all']
     ]))->orderBy('statement.stored', 'DESC')->paginate(15);
-
     return View::make('partials.statements.list', array_merge($this->getLrs($lrs_id), [
       'statements' => $statements,
       'statement_nav' => true,

--- a/app/controllers/ReportingController.php
+++ b/app/controllers/ReportingController.php
@@ -69,12 +69,14 @@ class ReportingController extends \BaseController {
    * @return reporting view.
    */
   public function index($lrs_id) {
+    $site = \Site::first();
     return View::make("{$this->views}.index", array_merge($this->getLrs($lrs_id), [
       'reporting_nav' => true,
       'reports' => $this->report->index([
         'lrs_id' => $lrs_id
       ]),
-      'client' => (new \Client)->where('lrs_id', $lrs_id)->first()
+      'client' => (new \Client)->where('lrs_id', $lrs_id)->first(),
+      'lang' => $site->lang
     ]));
   }
 
@@ -86,7 +88,6 @@ class ReportingController extends \BaseController {
    */
   public function statements($lrs_id, $report_id) {
     $site = \Site::first();
-
     return View::make("{$this->views}.statements", array_merge($this->getLrs($lrs_id), [
       'reporting_nav' => true,
       'statements' => $this->report->statements($report_id, [
@@ -108,7 +109,6 @@ class ReportingController extends \BaseController {
    **/
   public function typeahead($lrs, $segment, $query){
     $options = self::$segments[$segment];
-
     return Response::json($this->report->setQuery(
       $lrs,
       $query,

--- a/app/views/partials/reporting/index.blade.php
+++ b/app/views/partials/reporting/index.blade.php
@@ -5,7 +5,8 @@
   <script>
     window.lrs = {
       key: '{{ $client->api['basic_key']}}',
-      secret: '{{ $client->api['basic_secret'] }}'
+      secret: '{{ $client->api['basic_secret'] }}',
+      lang: '{{ $lang }}'
     };
   </script>
   {{ HTML::style('assets/css/exports.css')}}

--- a/app/views/partials/statements/item.blade.php
+++ b/app/views/partials/statements/item.blade.php
@@ -24,7 +24,7 @@
     $name = 'no name available';
   }
 
-  if( isset($statement['verb']['display']) ){
+ if( isset($statement['verb']['display']) ){
     $verb = $statement['verb']['display'];
     if (!is_array($verb)) {
       $verb = [$verb];

--- a/public/assets/js/reports/reports/editLayout.js
+++ b/public/assets/js/reports/reports/editLayout.js
@@ -114,28 +114,7 @@ define([
     relations: {
       actors: typeaheadHelpers.view('actors', 'Actor', 'Start typing name e.g. Bob', typeaheadHelpers.displayActor),
       verbs: typeaheadHelpers.view('verbs', 'Verb', 'Start typing verb e.g. completed', function (item) {
-        var id = item.id;
-        var value = null;
-
-        // Return a human-readable value if the browser defines languages.
-        if (navigator.languages instanceof Array) {
-          value = item.display && (navigator.languages.map(function (lang) {
-            return item.display[lang];
-          }).filter(function (value) {
-            return value != null;
-          })[0] || (item.display[Object.keys(item.display)[0]]));
-        }
-
-        // Display human-readable value if it exists
-        if (value != null) {
-          return value + ' (' + id + ')';
-        }
-
-        // Otherwise display just the identifier.
-        else {
-          return id
-        }
-        return item.display['en-GB'] + ' (' + id + ')';
+        return typeaheadHelpers.displayLangString(item.id, item.display);
       }),
       activities: typeaheadHelpers.view('activities', 'Activity URL', 'www.example.com/quiz/1'),
       activityTypes: typeaheadHelpers.view('activityTypes', 'Activity Type URL', 'www.example.com/activity-type/course', typeaheadHelpers.displayItem),

--- a/public/assets/js/reports/reports/typeaheadHelpers.js
+++ b/public/assets/js/reports/reports/typeaheadHelpers.js
@@ -5,27 +5,7 @@ define([
   var getKeys = function (display) {
     // Sets display to default if not set.
     display = display || function (item) {
-      var id = item.id;
-      var value = null;
-
-      // Return a human-readable value if the browser defines languages.
-      if (navigator.languages instanceof Array) {
-        value = item.definition && item.definition.name && (navigator.languages.map(function (lang) {
-          return item.definition.name[lang];
-        }).filter(function (value) {
-          return value != null;
-        })[0] || (item.definition.name[Object.keys(item.definition.name)[0]]));
-      }
-
-      // Display human-readable value if it exists
-      if (value != null) {
-        return value + ' (' + id + ')';
-      }
-
-      // Otherwise display just the identifier.
-      else {
-        return id;
-      }
+      return displayLangString(item.id, item.definition && item.definition.name);
     };
 
     return function (items, query) {
@@ -34,9 +14,11 @@ define([
       });
     };
   };
+
   var displayItem = function (item) {
     return item;
   };
+
   var displayActor = function (actor) {
     var id= '';
     var pre = '';
@@ -54,6 +36,7 @@ define([
     }
     return actor.name + ' (' + pre + id + ')';
   };
+
   var view = function (segment, type, example, display) {
     return CompositeView.extend({
       example: example,
@@ -65,10 +48,28 @@ define([
     });
   };
 
+  var displayLangString = function (id, langMap) {
+    var value = null;
+
+    // Return a human-readable value if the browser defines languages.
+    if (navigator.languages instanceof Array) {
+      value = langMap && ([window.lrs.lang].concat(navigator.languages || []).map(function (lang) {
+        return langMap[lang];
+      }).filter(function (value) {
+        return value != null;
+      })[0] || (langMap[Object.keys(langMap)[0]]));
+    }
+
+    // Display human-readable value if it exists. Otherwise display just the identifier.
+
+    return value != null ? (value + ' (' + id + ')') : id;
+  };
+
   return {
     getKeys: getKeys,
     displayItem: displayItem,
     displayActor: displayActor,
-    view: view
+    view: view,
+    displayLangString: displayLangString
   };
 });


### PR DESCRIPTION
Building on #693, when displaying a language map in a report, the TypeAhead/AutoComplete results are now displayed in the LRS's language by default. Displaying verbs in the browser's language has been preserved as a fallback.