### PR TITLE
Fixes invite when no role selected

### DIFF
--- a/app/locker/helpers/User.php
+++ b/app/locker/helpers/User.php
@@ -59,7 +59,7 @@ class User {
           $user->name   = $e;
           $user->email  = $e;
           $user->verified = 'no';
-          $user->role   = $data['role'] ? $data['role'] : 'observer';
+          $user->role   = isset($data['role']) ? $data['role'] : 'observer';
           $user->password = \Hash::make(base_convert(uniqid('pass', true), 10, 36));
           $user->save(); 
 


### PR DESCRIPTION
If no role was selected when inviting a user via the Admin dashboard, after submitting the form the Laravel error page is shown. This was solved by checking if the role `isset()`. The default behaviour of setting an unspecified role to Observer is preserved.