### PR TITLE
Enhancement: Rm some unnecessary resource request on /site page

### DIFF
--- a/app/controllers/SiteController.php
+++ b/app/controllers/SiteController.php
@@ -37,8 +37,8 @@ class SiteController extends BaseController {
     return View::make('partials.site.dashboard', [
       'site' => $site,
       'list' => $list,
-      'stats' => $admin_dashboard->getFullStats(),
-      'graph_data' => $admin_dashboard->getGraphData()
+      'stats' => [],
+      'graph_data' => []
     ]);
 
   }

--- a/app/routes.php
+++ b/app/routes.php
@@ -160,7 +160,6 @@ Route::post('site/invite', array(
 Route::get('site/plugins', array(
   'uses' => 'PluginController@index',
 ));
-Route::resource('site', 'SiteController');
 Route::put('site/users/verify/{id}', array(
   'uses' => 'SiteController@verifyUser',
   'as'   => 'user.verify'


### PR DESCRIPTION
I saw ```SiteController@index``` doesnt use data from ```AdminDashboard::getFullStats()``` and ```AdminDashboard:: getGraphData()```, remove those save quite some time for loading ```/site``` pages in a data heavy LL app

E.g.: Mine take ~ 20 secs to fresh load (url enter) in these pages: /site#settings /site#lrs and /site#users
Context: LL app with > 700k statements
Result: Come down to < 2s

Also i remove ```Route::resource('site', 'SiteController');``` declaration in routes.php (doesnt seem to be used anywhere)