### PR TITLE
Talk directly to the MongoCollection to perform the active update

### DIFF
--- a/app/locker/repository/Statement/EloquentReader.php
+++ b/app/locker/repository/Statement/EloquentReader.php
@@ -1,5 +1,6 @@
 <?php namespace Locker\Repository\Statement;
 
+use DB;
 use \Illuminate\Database\Eloquent\Model as Model;
 use \Locker\Helpers\Helpers as Helpers;
 use \Locker\Helpers\Exceptions as Exceptions;
@@ -34,5 +35,9 @@ abstract class EloquentReader {
    */
   protected function formatModel(Model $model) {
     return Helpers::replaceHtmlEntity($model->statement);
+  }
+
+  public function getCollection(){
+    return DB::getCollection((new $this->model)->getTable());
   }
 }

--- a/app/locker/repository/Statement/EloquentStorer.php
+++ b/app/locker/repository/Statement/EloquentStorer.php
@@ -97,9 +97,7 @@ class EloquentStorer extends EloquentReader implements Storer {
    * @param StoreOptions $opts
    */
   private function activateStatements(array $ids, StoreOptions $opts) {
-    return $this->where($opts)
-      ->whereIn('statement.id', $ids)
-      ->update(['active' => true]);
+    return $this->update( ['statement.id'=>['$in'=>$ids]], ['active' => true], $opts);
   }
 
   /**
@@ -118,5 +116,32 @@ class EloquentStorer extends EloquentReader implements Storer {
     
     return $uuid;
     
+  }
+
+  protected function update( array $conditions, $new_object, Options $opts) {
+    $collection = $this->getCollection();
+
+    $baseWheres = [
+      'lrs_id' => new \MongoId($opts->getOpt('lrs_id'))
+    ];
+
+    $scopes = $opts->getOpt('scopes');
+
+    if (in_array('all', $scopes) || in_array('all/read', $scopes) || in_array('statements/read', $scopes)) {
+      // Query all statements.
+    } else if (in_array('statements/read/mine', $scopes)) {
+      $baseWheres['client_id'] = $opts->getOpt('client')->_id;
+    } else {
+      throw new Exceptions\Exception('Unauthorized request.', 401);
+    }
+
+    $criteria = array_merge($baseWheres, $conditions);
+
+    // Use $set as default operator.
+    if (!starts_with(key($new_object), '$')) {
+        $new_object = array('$set' => $new_object);
+    }
+
+    return $collection->update($criteria, $new_object, ['multiple'=>true]);
   }
 }


### PR DESCRIPTION
The active update as constructed by the jenseggers/mongodb library was
seen to wrap the entire criteria (query) in an $and key. This was
preventing the database from utilising the index on the statement.id and
lrs_id leading to slow updates when performing bulk inserts via the
statement API.