### PR TITLE
add Event::fire('Statements.store') in createStatements

### DIFF
--- a/app/controllers/xapi/StatementStoreController.php
+++ b/app/controllers/xapi/StatementStoreController.php
@@ -131,13 +131,18 @@ class StatementStoreController {
     }
 
     // Saves $statements with attachments.
-    return $this->statements->store(
+    $rc = $this->statements->store(
       $statements,
       is_array($parts['attachments']) ? $parts['attachments'] : [],
       array_merge([
         'authority' => $this->getAuthority($options['client'])
       ], $options)
     );
+
+     // http://www.craighooghiem.com/application-hooks-with-laravel-events/
+     \Event::fire('Statements.store', array($statements));
+
+     return $rc;
   }
 
   private function getAuthority($client) {

--- a/app/controllers/xapi/StatementStoreController.php
+++ b/app/controllers/xapi/StatementStoreController.php
@@ -140,7 +140,7 @@ class StatementStoreController {
     );
 
      // http://www.craighooghiem.com/application-hooks-with-laravel-events/
-     \Event::fire('Statements.store', array($statements));
+     \Event::fire('Statements.store', array(&$statements));
 
      return $rc;
   }


### PR DESCRIPTION
Hi,

We are planning a LearningLocker - RabbitMQ integration.

We need a hook in StatementStoreController::createStatements().

May be there are more places to hook...

Thanx for this great software.