### PR TITLE
URL decodes params payload

### DIFF
--- a/app/locker/request/Request.php
+++ b/app/locker/request/Request.php
@@ -37,8 +37,10 @@ class Request {
    * @return AssocArray params from the payload.
    */
   public function getPayloadParams() {
+    $payload = $this->getPayload();
+    $decodedPayload = urldecode($payload);
     $payloadParams = [];
-    parse_str($this->getPayload(), $payloadParams); // Parse the payload into an AssocArray.
+    parse_str($decodedPayload, $payloadParams); // Parse the payload into an AssocArray.
     $payloadParams = json_decode(json_encode($payloadParams), true);
     return $payloadParams;
   }


### PR DESCRIPTION
Noticed that when params are sent as POST payload, and Authorization has a `+` value encoded for a space, it was not decoding the value and would fail when trying to retrieve the basic auth information.