### PR TITLE
Force a hint on statement counts for an LRS

### DIFF
--- a/app/locker/repository/Lrs/EloquentRepository.php
+++ b/app/locker/repository/Lrs/EloquentRepository.php
@@ -167,7 +167,7 @@ class EloquentRepository extends BaseRepository implements Repository {
       $query['lrs_id'] = $lrs_id;
     }
 
-    return $collection->count($query);
+    return $collection->count($query, ['hint'=>['lrs_id'=>1]]);
   }
 
   public function changeRole($id, $user_id, $role) {


### PR DESCRIPTION
Seeing different index selection between Mongo versions - this will enforce correct index usage on this query.