### PR TITLE
Convert matches on string dates to native ones

### DIFF
--- a/app/config/xapi.php
+++ b/app/config/xapi.php
@@ -14,7 +14,11 @@
   | only one of the passed keys in. 
   | See https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#user-content-2.2.s2.b2
   |
+  | ** aggregate_on_native_dates **
+  | Any aggregation querying on "statement.timestamp" or "statement.stored" will
+  | be automatically changed to query on the native MongoDate at the root of the document
   */
   return [
     'disable_duplicate_key_checks' => false,
+    'aggregate_on_native_dates' => false,
   ];

--- a/app/locker/repository/Client/EloquentRepository.php
+++ b/app/locker/repository/Client/EloquentRepository.php
@@ -76,7 +76,6 @@ class EloquentRepository extends BaseRepository implements Repository {
    * @return Model
    */
   protected function constructUpdate(Model $model, array $data, array $opts) {
-    //dd($data);
     $this->validateData($data);
 
     // Sets properties on model.


### PR DESCRIPTION
Added a custom config to enable converting queries on statement.stored or
statement.timestamp to native MongoDate queries on the root of the
document.