### PR TITLE
Remove UI_PORT from URL in `.env.example`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 NODE_ENV=production
 
 # Site URL (used for emails)
-SITE_URL=http://127.0.0.1:3000
+SITE_URL=http://127.0.0.1
 
 #########
 # PORTS #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Format based on [Keep a Changelog](http://keepachangelog.com/)
 ## [unreleased]
 ### Added
 ### Changed
+ - Tidy up unused variables in .env.example 
 ### Deprecated
 ### Removed
 ### Fixed


### PR DESCRIPTION
If using the nginx configuration example then this should not be required, as all things are routed there anyway