### PR TITLE
Enable .env config to override system email address

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,14 +120,14 @@ GOOGLE_ENABLED=false
 ########
 
 # SMTP credentials
-#SMTP_HOST= # 127.0.0.1
-#SMTP_PORT= # 587
-#SMTP_SECURED= # true
-#SMTP_USER= # user
-#SMTP_PASS= # password
+#SMTP_HOST=127.0.0.1
+#SMTP_PORT=587
+#SMTP_SECURED=true
+#SMTP_USER=user
+#SMTP_PASS=password
 
-#LL_FROM_NAME = # "Learning Locker"
-#LL_FROM_EMAIL = # noreply@learninglocker.net
+#LL_FROM_NAME="Learning Locker"
+#LL_FROM_EMAIL=noreply@learninglocker.net
 
 ##########
 # Queues #

--- a/.env.example
+++ b/.env.example
@@ -126,6 +126,9 @@ GOOGLE_ENABLED=false
 #SMTP_USER= # user
 #SMTP_PASS= # password
 
+#LL_FROM_NAME = # "Learning Locker"
+#LL_FROM_EMAIL = # noreply@learninglocker.net
+
 ##########
 # Queues #
 ##########

--- a/lib/helpers/email.js
+++ b/lib/helpers/email.js
@@ -1,11 +1,13 @@
 import logger from 'lib/logger';
 import transporter from 'lib/connections/nodemailer';
 import _ from 'lodash';
+import defaultTo from 'lodash/defaultTo';
 import fs from 'fs';
 import htmlToText from 'html-to-text';
 
 const defaultMailOptions = {
-  from: `${process.env.LL_FROM_NAME} <${process.env.LL_FROM_EMAIL}>` || 'Learning Locker <noreply@learninglocker.net>'
+  from: `${defaultTo(process.env.LL_FROM_NAME, 'Learning Locker')} ` +
+        `<${defaultTo(process.env.LL_FROM_EMAIL, 'noreply@learninglocker.net')}>`
 };
 
 const siteUrl = () =>

--- a/lib/helpers/email.js
+++ b/lib/helpers/email.js
@@ -5,7 +5,7 @@ import fs from 'fs';
 import htmlToText from 'html-to-text';
 
 const defaultMailOptions = {
-  from: 'Learning Locker <noreply@learninglocker.net>',
+  from: `${process.env.LL_FROM_NAME} <${process.env.LL_FROM_EMAIL}>` || 'Learning Locker <noreply@learninglocker.net>'
 };
 
 const siteUrl = () =>


### PR DESCRIPTION
Most email gateways will not allow using a non-domain address for the "from" in outbound emails they deliver.  This prevents the emailer working in Learning Locker.

This config change will let you override the default name/address in the config to enable delivery.