### PR TITLE
fix: Adds validation for IFIs to the API.

### DIFF
--- a/api/src/controllers/PersonaIdentifierController.js
+++ b/api/src/controllers/PersonaIdentifierController.js
@@ -19,6 +19,7 @@ import {
   omitBy,
 } from 'lodash';
 import { entityResponse, entitiesResponse } from 'api/controllers/utils/entitiesResponse';
+import validateIfi from 'lib/services/persona/validateIfi';
 
 const objectId = mongoose.Types.ObjectId;
 
@@ -80,6 +81,7 @@ const addPersonaIdentifier = catchErrors(async (req, res) => {
   });
 
   const organisation = getOrgFromAuthInfo(authInfo);
+  validateIfi(req.body.ifi, ['body', 'ifi']);
 
   const { identifier } = await personaService.createIdentifier({
     ifi: req.body.ifi,
@@ -109,6 +111,8 @@ const upsertPersonaIdentifier = catchErrors(async (req, res) => {
   });
 
   const organisation = getOrgFromAuthInfo(authInfo);
+  validateIfi(req.body.ifi, ['body', 'ifi']);
+
   const toPersona = req.body.persona;
   if (!toPersona) {
     try {

--- a/api/src/routes/tests/personaController/postIdentifier-test.js
+++ b/api/src/routes/tests/personaController/postIdentifier-test.js
@@ -34,7 +34,7 @@ describe('personaController postIdentifier', () => {
         ifi: {
           key: 'account',
           value: {
-            homePage: 'test@test.com',
+            homePage: 'http://example.org',
             name: 'test'
           }
         },
@@ -42,7 +42,7 @@ describe('personaController postIdentifier', () => {
       })
       .expect(200);
 
-    expect(result.body.ifi.value.homePage).to.equal('test@test.com');
+    expect(result.body.ifi.value.homePage).to.equal('http://example.org');
     expect(result.body.ifi.value.name).to.equal('test');
     expect(result.body.ifi.key).to.equal('account');
     expect(result.body.persona).to.equal(persona.id);

--- a/lib/services/persona/validateIfi.js
+++ b/lib/services/persona/validateIfi.js
@@ -1,0 +1,26 @@
+import validateMailto from '@learninglocker/xapi-validation/dist/regexValues/mailto';
+import validateIri from '@learninglocker/xapi-validation/dist/regexValues/iri';
+import validateSha1 from '@learninglocker/xapi-validation/dist/regexValues/sha1';
+import { restrictToSchema, required, checkType, maybe } from 'rulr';
+
+const validateIfi = (ifi, path) => {
+  const valuePath = [...path, 'value'];
+  if (ifi.key === 'mbox') {
+    return validateMailto(ifi.value, valuePath);
+  }
+  if (ifi.key === 'mbox_sha1sum') {
+    return validateSha1(ifi.value, valuePath);
+  }
+  if (ifi.key === 'openid') {
+    return validateIri(ifi.value, valuePath);
+  }
+  if (ifi.key === 'account') {
+    return restrictToSchema({
+      homePage: required(validateIri),
+      name: required(checkType(String))
+    })(ifi.value, valuePath);
+  }
+  return ['invalid key'];
+};
+
+export default maybe(validateIfi);


### PR DESCRIPTION
I also need to change the mbox_sha1sum validation on the client side because it doesn't actually ensure it's a valid sha1. We'll also need to decide if we want me to add the "mailto:" to mbox IFIs if it's missing when you create IFIs via the API.