### PR TITLE
fix for sending secured smtp emails

### DIFF
--- a/lib/connections/nodemailer.js
+++ b/lib/connections/nodemailer.js
@@ -4,7 +4,7 @@ import nodemailer from 'nodemailer';
 const smtpConfig = {
   host: process.env.SMTP_HOST,
   port: process.env.SMTP_PORT,
-  secure: false,
+  secure: process.env.SMTP_SECURED,
   auth: {
     user: process.env.SMTP_USER,
     pass: process.env.SMTP_PASS


### PR DESCRIPTION
Small fix for sending secured smtp emails. Current .env was being ignored. Fixes issue #1107