### PR TITLE
Keep $sample as first in aggregate pipeline, for efficiency fixes 1291

### DIFF
--- a/lib/models/statement.js
+++ b/lib/models/statement.js
@@ -179,6 +179,11 @@ schema.statics.aggregateByAuth = function aggregateByAuth(
     const scopedFilter = await getScopeFilter({ modelName, actionName, authInfo });
     const organisation = getOrgFromAuthInfo(authInfo);
 
+    let sampleStatement = null;
+    if (parsedPipeline.length > 0 && parsedPipeline[0]['$sample']) {
+      sampleStatement = parsedPipeline.shift();
+    }
+
     parsedPipeline.unshift({
       $match: scopedFilter
     });
@@ -186,6 +191,10 @@ schema.statics.aggregateByAuth = function aggregateByAuth(
     // if we are using client based auth, filter by the lrs_id (if exist)
     if (authInfo.client && authInfo.client.lrs_id) {
       parsedPipeline.unshift({ $match: { lrs_id: objectId(authInfo.client.lrs_id) } });
+    }
+
+    if (sampleStatement) {
+      parsedPipeline.unshift(sampleStatement);
     }
     const finalPipeline = removeEmptyMatch(parsedPipeline);
 


### PR DESCRIPTION
This PR makes sure that in an aggregate query, a `$sample: { size: size }` statement that occurs as a first in the pipeline stays the first in the pipeline.  This is important for the way mongo executes the sample, when it is a first, the collection is really sampled, [otherwise a full scan is made](https://docs.mongodb.com/manual/reference/operator/aggregation/sample/#pipe._S_sample), and the result is sorted randomly, which is way less efficient. 