### PR TITLE
updated to make sending auth optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,13 +12,13 @@ SITE_URL=http://127.0.0.1
 UI_PORT=3000
 
 # If UI is on a different host
-#UI_HOST
+#UI_HOST=127.0.0.1
 
 # Expose the API on this port
 API_PORT=8080
 
 # If API is on a different host.
-#API_HOST
+#API_HOST=127.0.0.1
 
 # Use an additional port for unit tests
 #TEST_API_PORT=808080
@@ -135,9 +135,9 @@ GOOGLE_ENABLED=false
 #SMTP_REQUIRE_TLS=false
 
 # If your SMTP server/relay does not have SMTP AUTH,
-# IE treats all local connections as already authenticated.
-# Then set this to false, default is true you do want SMTP AUTH.
-#SMTP_AUTH_REQ=true
+# (i.e. treats all local connections as already authenticated),
+# then set this to false, default is true you do want SMTP AUTH.
+#SMTP_AUTH_REQUEST=true
 
 #LL_FROM_NAME="Learning Locker"
 #LL_FROM_EMAIL=noreply@learninglocker.net

--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,14 @@ SITE_URL=http://127.0.0.1
 # Expose the UI on this port
 UI_PORT=3000
 
+# If UI is on a different host
+#UI_HOST
+
 # Expose the API on this port
 API_PORT=8080
+
+# If API is on a different host.
+#API_HOST
 
 # Use an additional port for unit tests
 #TEST_API_PORT=808080
@@ -127,6 +133,10 @@ GOOGLE_ENABLED=false
 #SMTP_SECURED=false
 #SMTP_IGNORE_TLS=false
 #SMTP_REQUIRE_TLS=false
+
+# If your SMTP server/relay does not have any AUTH values set,
+# IE treats all local connections as already authenticated.
+#SMTP_AUTH_REQ=false
 
 #LL_FROM_NAME="Learning Locker"
 #LL_FROM_EMAIL=noreply@learninglocker.net

--- a/.env.example
+++ b/.env.example
@@ -134,9 +134,10 @@ GOOGLE_ENABLED=false
 #SMTP_IGNORE_TLS=false
 #SMTP_REQUIRE_TLS=false
 
-# If your SMTP server/relay does not have any AUTH values set,
+# If your SMTP server/relay does not have SMTP AUTH,
 # IE treats all local connections as already authenticated.
-#SMTP_AUTH_REQ=false
+# Then set this to false, default is true you do want SMTP AUTH.
+#SMTP_AUTH_REQ=true
 
 #LL_FROM_NAME="Learning Locker"
 #LL_FROM_EMAIL=noreply@learninglocker.net

--- a/lib/connections/nodemailer.js
+++ b/lib/connections/nodemailer.js
@@ -12,9 +12,9 @@ const smtpConfig = {
 };
 
 // Placed like this since the boolean set default can be hard to read in an if condition.
-const sendAuthRequest = boolean(defaultTo(process.env.SMTP_AUTH_REQ, true));
+const sendAuthRequest = boolean(defaultTo(process.env.SMTP_AUTH_REQUEST, true));
 
-//Do not want the auth object in the smtpConfig object if sendAuthRequest is false, default is true.
+// Do not want the auth object in the smtpConfig object if sendAuthRequest is false, default is true.
 if (sendAuthRequest) {
   Object.assign(smtpConfig, {
     auth: {

--- a/lib/connections/nodemailer.js
+++ b/lib/connections/nodemailer.js
@@ -8,21 +8,32 @@ const smtpConfig = {
   port: process.env.SMTP_PORT,
   secure: boolean(defaultTo(process.env.SMTP_SECURED, false)),
   ignoreTLS: boolean(defaultTo(process.env.SMTP_IGNORE_TLS, false)),
-  requireTLS: boolean(defaultTo(process.env.SMTP_REQUIRE_TLS, false)),
-  auth: {
-    user: process.env.SMTP_USER,
-    pass: process.env.SMTP_PASS
-  }
+  requireTLS: boolean(defaultTo(process.env.SMTP_REQUIRE_TLS, false))
 };
+
+// Placed like this since the boolean set default can be hard to read in an if condition.
+const sendAuthRequest = boolean(defaultTo(process.env.SMTP_AUTH_REQ, true));
+
+//Do not want the auth object in the smtpConfig object if sendAuthRequest is false, default is true.
+if (sendAuthRequest) {
+  Object.assign(smtpConfig, {
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS
+    }
+  });
+}
 
 let mailer; //eslint-disable-line
 
 if (process.env.TESTING) {
-  mailer = { sendMail: (opts) => {
-    // @TODO: this is quite annoying when pumped into the stdout during testing
-    // better solution?
-    logger.debug(`Pretending to email ${opts.to}`);
-  } };
+  mailer = {
+    sendMail: (opts) => {
+      // @TODO: this is quite annoying when pumped into the stdout during testing
+      // better solution?
+      logger.debug(`Pretending to email ${opts.to}`);
+    }
+  };
 } else {
   mailer = nodemailer.createTransport(smtpConfig);
 }


### PR DESCRIPTION
Updated to resolve issue 1306. And added additional keys to the .env.example file to allow people to find the additional settings later. This is to prevent nodemailer from sending a plain AUTH request to a relay or smtp server that does not have any auth types listed, IE "205-AUTH" instead of "205-AUTH PLAIN LOGIN". For some reason nodemailer does not automatically do this if username and password is set to blank, I assume they have their reasons. 