### PR TITLE
fix(Indexes): Change statement.id index to ignore organisation

### DIFF
--- a/cli/src/commands/v2-migrations/20171122100800_common_indexes.js
+++ b/cli/src/commands/v2-migrations/20171122100800_common_indexes.js
@@ -31,7 +31,7 @@ const createStatementIndexes = (connection) => {
   createIndexWithVoid('account', accountIndex);
   createIndexWithVoid('timestamp__id', { timestamp: -1, _id: -1 });
   createIndexWithVoid('stored__id', { stored: -1, _id: -1 });
-  createIndexWithStore('statementId', { 'statement.id': 1 });
+  createIndex('statementId_lrs_id', { 'statement.id': 1, lrs_id: 1 });
   createIndexWithOrg('timestamp__id', { timestamp: -1, _id: 1 });
   createIndexWithOrg('stored__id', { stored: -1, _id: 1 });
   createIndexWithOrg('objId', objectIdIndex);

--- a/cli/src/commands/v2-migrations/20171122100800_common_indexes.js
+++ b/cli/src/commands/v2-migrations/20171122100800_common_indexes.js
@@ -31,7 +31,7 @@ const createStatementIndexes = (connection) => {
   createIndexWithVoid('account', accountIndex);
   createIndexWithVoid('timestamp__id', { timestamp: -1, _id: -1 });
   createIndexWithVoid('stored__id', { stored: -1, _id: -1 });
-  createIndex('statementId_lrs_id', { 'statement.id': 1, lrs_id: 1 });
+  createIndex(stmts, 'statementId_lrs_id', { 'statement.id': 1, lrs_id: 1 });
   createIndexWithOrg('timestamp__id', { timestamp: -1, _id: 1 });
   createIndexWithOrg('stored__id', { stored: -1, _id: 1 });
   createIndexWithOrg('objId', objectIdIndex);


### PR DESCRIPTION
Currently creates the index as `{organisation: 1, lrs_id: 1, "statement.id": 1}`