### PR TITLE
fix(Workers): Add better error logging to SQS failures

### DIFF
--- a/lib/services/queue/sqs/index.js
+++ b/lib/services/queue/sqs/index.js
@@ -205,7 +205,7 @@ export const subscribe = ({
     // wrap the jobDone callback to check if an error was passed
     return handler(payload, (err) => {
       if (err) {
-        logger.error(`SQS HANDLE JOB: ${queueName}`, err, payload);
+        logger.error(`SQS HANDLE JOB: ${queueName}`, payload, err);
       }
       return jobDone(err);
     });

--- a/lib/services/queue/sqs/index.js
+++ b/lib/services/queue/sqs/index.js
@@ -205,7 +205,7 @@ export const subscribe = ({
     // wrap the jobDone callback to check if an error was passed
     return handler(payload, (err) => {
       if (err) {
-        logger.error('SQS HANDLE JOB', err);
+        logger.error(`SQS HANDLE JOB: ${queueName}`, err, payload);
       }
       return jobDone(err);
     });

--- a/worker/src/handlers/statement/wrapHandlerForStatement.js
+++ b/worker/src/handlers/statement/wrapHandlerForStatement.js
@@ -12,13 +12,14 @@ export default (queueName, statementHandler) => ({ statementId }, jobDone, optio
         return jobDone(err);
       }
       try {
+        const payload = { status: queueName, statementId };
         return Queue.publish({
           queueName: STATEMENT_QUEUE,
-          payload: { status: queueName, statementId },
+          payload,
           opts: { lifo: true }
         }, jobDone);
       } catch (err) {
-        logger.error(`Error publishing back to ${STATEMENT_QUEUE}`, payload, err);
+        logger.error(`Error publishing status back to ${STATEMENT_QUEUE}`, payload, err);
         return jobDone(err);
       }
     }, options);

--- a/worker/src/handlers/statement/wrapHandlerForStatement.js
+++ b/worker/src/handlers/statement/wrapHandlerForStatement.js
@@ -9,7 +9,6 @@ export default (queueName, statementHandler) => ({ statementId }, jobDone, optio
     statementHandler(statement, (err) => {
       logger.debug('COMPLETED STATEMENT HANDLER FOR', queueName, statementId);
       if (err) {
-        logger.error('ERROR', queueName, err);
         return jobDone(err);
       }
       try {
@@ -19,7 +18,7 @@ export default (queueName, statementHandler) => ({ statementId }, jobDone, optio
           opts: { lifo: true }
         }, jobDone);
       } catch (err) {
-        logger.error('Queue.publish error', err);
+        logger.error(`Error publishing back to ${STATEMENT_QUEUE}`, payload, err);
         return jobDone(err);
       }
     }, options);

--- a/worker/src/handlers/statement/wrapHandlerForStatement.js
+++ b/worker/src/handlers/statement/wrapHandlerForStatement.js
@@ -11,8 +11,8 @@ export default (queueName, statementHandler) => ({ statementId }, jobDone, optio
       if (err) {
         return jobDone(err);
       }
+      const payload = { status: queueName, statementId };
       try {
-        const payload = { status: queueName, statementId };
         return Queue.publish({
           queueName: STATEMENT_QUEUE,
           payload,


### PR DESCRIPTION
#### Which issue does this close?
n/a

#### Describe your changes providing screenshots of UI changes if necessary.
Currently the SQS worker outputs `[ERROR] SQS HANDLE JOB` plus the JS error. Would be much more useful to see which queue and payload led to the error