### PR TITLE
Fix query building of 'Store'

### DIFF
--- a/ui/src/redux/modules/queryBuilder.js
+++ b/ui/src/redux/modules/queryBuilder.js
@@ -379,6 +379,7 @@ export const initialSections = fromJS({
   stores: {
     title: 'Store',
     keyPath: new List(['lrs_id']),
+    getQueryKey: 'lrs_id',
     sourceSchema: 'lrs',
     getModelIdent: model => model.get('_id'),
     getModelDisplay: (model) => {
@@ -386,11 +387,9 @@ export const initialSections = fromJS({
       const count = model.get('statementCount', 0);
       return `${title} (${count} statements)`;
     },
-    getModelQuery: model => new Map({
-      lrs_id: new Map({ $oid: model.get('_id') })
-    }),
+    getModelQuery: model => new Map({ $oid: model.get('_id') }),
     getQueryModel: query => new Map({
-      _id: query.get('lrs_id')
+      _id: new Map({ $oid: query.get('$oid') }),
     }),
     operators: operators.DISCRETE,
   },


### PR DESCRIPTION
# Issue

### replication steps

- You have some LRSs.
- Go to Visualisation > Series > "Build your query"
- Open "Store" and select LRS options
- See the query in JSON by clicking "toggle edit mode"

### actual behaviour

- No Data
- query is invalid like below

```
{
  "$and": [
    {
      "$comment": "{\"criterionLabel\":\"A\",\"criteriaPath\":[\"lrs_id\"]}",
      "": { // <--- ❗empty key❗
        "lrs_id": {
          "$in": [
            {
              "$oid": "5cd19886c3c2a411930b11b3"
            },
            {
              "$oid": "5cd19886c3c2a411930b11b4"
            }
          ]
        }
      }
    }
  ]
}
```

### expected behaviour

- Result is same with $or version query
- query is valid

```
{
  "$and": [
    {
      "$comment": "{\"criterionLabel\":\"A\",\"criteriaPath\":[\"lrs_id\"]}",
      "lrs_id": {
        "$in": [
          {
            "$oid": "5cd19886c3c2a411930b11b3"
          },
          {
            "$oid": "5cd19886c3c2a411930b11b4"
          }
        ]
      }
    }
  ]
}
```

# This PR did

- Fix query building logic of "Store"

# Test

- $in/$nin version result is same with $or/$nor version.
- $in migration command is also succeeded.

```
$ node cli/dist/server migrateToInQueries
...
2019-05-07 16:13:37:029 - info: Update Visualisation (5cd19894c3c2a411930b11b5)
2019-05-07 16:13:37:029 - info: convert filters
2019-05-07 16:13:37:029 - info:  
[ '{"$match":{"$and":[{"$comment":"{\\"criterionLabel\\":\\"A\\",\\"criteriaPath\\":[\\"lrs_id\\"]}","$or":[{"lrs_id":{"$oid":"5cd19886c3c2a411930b11b3"}},{"lrs_id":{"$oid":"5c8fcad999d8369641f14968"}}]}]}}' ]
2019-05-07 16:13:37:029 - info:  
[ '{"$match":{"$and":[{"$comment":"{\\"criterionLabel\\":\\"A\\",\\"criteriaPath\\":[\\"lrs_id\\"]}","lrs_id":{"$in":[{"$oid":"5cd19886c3c2a411930b11b3"},{"$oid":"5c8fcad999d8369641f14968"}]}}]}}' ]
```