### PR TITLE
fix(JWTAuthentication): unexpected 500 responses

### DIFF
--- a/api/src/auth/passport.js
+++ b/api/src/auth/passport.js
@@ -98,7 +98,7 @@ async function verifyToken(token, done) {
     return auth;
   } catch (err) {
     if (err.name === 'TokenExpiredError' || err.name === 'JsonWebTokenError') {
-      return done(new Unauthorized('Token expired'));
+      return done(null, false);
     }
     logger.error('Auth error:', err);
     done(err);


### PR DESCRIPTION
#### Describe your changes providing screenshots of UI changes if necessary.

How to simulate requests with expired JWT

- Set a short time, e.g. '10s', to `expiresIn` in api/src/auth
  - https://github.com/LearningLocker/learninglocker/blob/12892111d74a27c473891b36b2b8eef2926ba788/api/src/auth/jwt.js#L52
- Login and wait some seconds, and move pages. It will dispatch API Request to /api/connection
- The responses code of /api/connection should be 401, instead of 500, which is before fixing.
