### PR TITLE
Refactor visualisations buildModel

### DIFF
--- a/ui/src/containers/Visualisations/TemplateActivityOverTime/Card.js
+++ b/ui/src/containers/Visualisations/TemplateActivityOverTime/Card.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Map } from 'immutable';
-import { TEMPLATE_ACTIVITY_OVER_TIME } from 'lib/constants/visualise';
-import { FREQUENCY_IMAGE } from 'ui/components/VisualiseIcon/assets';
-import { LAST_2_MONTHS } from 'ui/utils/constants';
 import TemplateCard from '../components/TemplateCard';
+import buildModel from './buildModel';
+import { title, image } from './constants';
 
 /**
  * @param {immutable.Map} props.model
@@ -15,16 +14,9 @@ const Card = ({
   saveModel,
 }) => (
   <TemplateCard
-    title="How has activity changed over time?"
-    srcImage={FREQUENCY_IMAGE}
-    onClick={() => {
-      saveModel({
-        attrs: model
-          .set('type', TEMPLATE_ACTIVITY_OVER_TIME)
-          .set('description', 'How has activity changed over time?')
-          .set('previewPeriod', LAST_2_MONTHS),
-      });
-    }} />
+    title={title}
+    srcImage={image}
+    onClick={() => saveModel({ attrs: buildModel(model) })} />
 );
 
 Card.propTypes = {
@@ -32,4 +24,4 @@ Card.propTypes = {
   saveModel: PropTypes.func.isRequired,
 };
 
-export default React.memo(Card);
+ export default React.memo(Card);

--- a/ui/src/containers/Visualisations/TemplateActivityOverTime/Card.js
+++ b/ui/src/containers/Visualisations/TemplateActivityOverTime/Card.js
@@ -24,4 +24,4 @@ Card.propTypes = {
   saveModel: PropTypes.func.isRequired,
 };
 
- export default React.memo(Card);
+export default React.memo(Card);

--- a/ui/src/containers/Visualisations/TemplateActivityOverTime/buildModel.js
+++ b/ui/src/containers/Visualisations/TemplateActivityOverTime/buildModel.js
@@ -1,0 +1,20 @@
+import { Map } from 'immutable';
+import { TEMPLATE_ACTIVITY_OVER_TIME } from 'lib/constants/visualise';
+import { LAST_2_MONTHS } from 'ui/utils/constants';
+import { description } from './constants';
+
+/**
+ * @param {immutable.Map} model
+ * @returns {immutable.Map}
+ */
+const buildModel = model =>
+  model
+    .set('type', TEMPLATE_ACTIVITY_OVER_TIME)
+    .set('description', description)
+    .set('axesoperator', 'uniqueCount')
+    .set('axesvalue', new Map({ optionKey: 'statements', searchString: 'Statements' }))
+    .set('axesxLabel', 'Date')
+    .set('axesyLabel', 'Statements')
+    .set('previewPeriod', LAST_2_MONTHS);
+
+export default buildModel;

--- a/ui/src/containers/Visualisations/TemplateActivityOverTime/constants.js
+++ b/ui/src/containers/Visualisations/TemplateActivityOverTime/constants.js
@@ -1,4 +1,3 @@
-
 import { FREQUENCY_IMAGE } from 'ui/components/VisualiseIcon/assets';
 
 export const title = 'How has activity changed over time?';

--- a/ui/src/containers/Visualisations/TemplateActivityOverTime/constants.js
+++ b/ui/src/containers/Visualisations/TemplateActivityOverTime/constants.js
@@ -1,0 +1,6 @@
+
+import { FREQUENCY_IMAGE } from 'ui/components/VisualiseIcon/assets';
+
+export const title = 'How has activity changed over time?';
+export const description = 'How has activity changed over time?';
+export const image = FREQUENCY_IMAGE;

--- a/ui/src/containers/Visualisations/TemplateLast7DaysStatements/Card.js
+++ b/ui/src/containers/Visualisations/TemplateLast7DaysStatements/Card.js
@@ -24,4 +24,4 @@ Card.propTypes = {
   saveModel: PropTypes.func.isRequired,
 };
 
- export default React.memo(Card);
+export default React.memo(Card);

--- a/ui/src/containers/Visualisations/TemplateLast7DaysStatements/Card.js
+++ b/ui/src/containers/Visualisations/TemplateLast7DaysStatements/Card.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Map } from 'immutable';
-import { TEMPLATE_LAST_7_DAYS_STATEMENTS } from 'lib/constants/visualise';
-import { COUNTER_IMAGE } from 'ui/components/VisualiseIcon/assets';
 import TemplateCard from '../components/TemplateCard';
+import buildModel from './buildModel';
+import { title, image } from './constants';
 
 /**
  * @param {immutable.Map} props.model
@@ -14,15 +14,9 @@ const Card = ({
   saveModel,
 }) => (
   <TemplateCard
-    title="How many statements have been stored in the last 7 days?"
-    srcImage={COUNTER_IMAGE}
-    onClick={() => {
-      saveModel({
-        attrs: model
-          .set('type', TEMPLATE_LAST_7_DAYS_STATEMENTS)
-          .set('description', 'How many statements have been stored in the last 7 days?')
-      });
-    }} />
+    title={title}
+    srcImage={image}
+    onClick={() => saveModel({ attrs: buildModel(model) })} />
 );
 
 Card.propTypes = {
@@ -30,4 +24,4 @@ Card.propTypes = {
   saveModel: PropTypes.func.isRequired,
 };
 
-export default React.memo(Card);
+ export default React.memo(Card);

--- a/ui/src/containers/Visualisations/TemplateLast7DaysStatements/buildModel.js
+++ b/ui/src/containers/Visualisations/TemplateLast7DaysStatements/buildModel.js
@@ -1,0 +1,18 @@
+import { Map } from 'immutable';
+import { TEMPLATE_LAST_7_DAYS_STATEMENTS } from 'lib/constants/visualise';
+import { LAST_7_DAYS } from 'ui/utils/constants';
+import { description } from './constants';
+
+/**
+ * @param {immutable.Map} model
+ * @returns {immutable.Map}
+ */
+const buildModel = model =>
+  model
+    .set('type', TEMPLATE_LAST_7_DAYS_STATEMENTS)
+    .set('description', description)
+    .set('axesoperator', 'uniqueCount')
+    .set('axesvalue', new Map({ optionKey: 'statements', searchString: 'Statements' }))
+    .set('previewPeriod', LAST_7_DAYS);
+
+export default buildModel;

--- a/ui/src/containers/Visualisations/TemplateLast7DaysStatements/constants.js
+++ b/ui/src/containers/Visualisations/TemplateLast7DaysStatements/constants.js
@@ -1,0 +1,5 @@
+import { COUNTER_IMAGE } from 'ui/components/VisualiseIcon/assets';
+
+export const title = 'How many statements have been stored in the last 7 days?';
+export const description = 'How many statements have been stored in the last 7 days?';
+export const image = COUNTER_IMAGE;

--- a/ui/src/containers/Visualisations/TemplateMostActivePeople/Card.js
+++ b/ui/src/containers/Visualisations/TemplateMostActivePeople/Card.js
@@ -24,4 +24,4 @@ Card.propTypes = {
   saveModel: PropTypes.func.isRequired,
 };
 
- export default React.memo(Card);
+export default React.memo(Card);

--- a/ui/src/containers/Visualisations/TemplateMostActivePeople/Card.js
+++ b/ui/src/containers/Visualisations/TemplateMostActivePeople/Card.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Map } from 'immutable';
-import { TEMPLATE_MOST_ACTIVE_PEOPLE } from 'lib/constants/visualise';
-import { LEADERBOARD_IMAGE } from 'ui/components/VisualiseIcon/assets';
-import { LAST_2_MONTHS } from 'ui/utils/constants';
 import TemplateCard from '../components/TemplateCard';
+import buildModel from './buildModel';
+import { title, image } from './constants';
 
 /**
  * @param {immutable.Map} props.model
@@ -15,17 +14,9 @@ const Card = ({
   saveModel,
 }) => (
   <TemplateCard
-    title="Who are the most active people?"
-    srcImage={LEADERBOARD_IMAGE}
-    onClick={() => {
-      saveModel({
-        attrs: model
-          .set('type', TEMPLATE_MOST_ACTIVE_PEOPLE)
-          .set('description', 'Who are the most active people?')
-          .set('previewPeriod', LAST_2_MONTHS)
-          .set('axesgroup', new Map({ optionKey: 'people', searchString: 'Person' })),
-      });
-    }} />
+    title={title}
+    srcImage={image}
+    onClick={() => saveModel({ attrs: buildModel(model) })} />
 );
 
 Card.propTypes = {
@@ -33,4 +24,4 @@ Card.propTypes = {
   saveModel: PropTypes.func.isRequired,
 };
 
-export default React.memo(Card);
+ export default React.memo(Card);

--- a/ui/src/containers/Visualisations/TemplateMostActivePeople/buildModel.js
+++ b/ui/src/containers/Visualisations/TemplateMostActivePeople/buildModel.js
@@ -1,0 +1,21 @@
+import { Map } from 'immutable';
+import { TEMPLATE_MOST_ACTIVE_PEOPLE } from 'lib/constants/visualise';
+import { LAST_2_MONTHS } from 'ui/utils/constants';
+import { description } from './constants';
+
+/**
+ * @param {immutable.Map} model
+ * @returns {immutable.Map}
+ */
+const buildModel = model =>
+  model
+    .set('type', TEMPLATE_MOST_ACTIVE_PEOPLE)
+    .set('description', description)
+    .set('axesgroup', new Map({ optionKey: 'people', searchString: 'Person' }))
+    .set('axesoperator', 'uniqueCount')
+    .set('axesvalue', new Map({ optionKey: 'statements', searchString: 'Statements' }))
+    .set('axesxLabel', 'Statements')
+    .set('axesyLabel', 'Person')
+    .set('previewPeriod', LAST_2_MONTHS);
+
+export default buildModel;

--- a/ui/src/containers/Visualisations/TemplateMostActivePeople/constants.js
+++ b/ui/src/containers/Visualisations/TemplateMostActivePeople/constants.js
@@ -1,0 +1,5 @@
+import { LEADERBOARD_IMAGE } from 'ui/components/VisualiseIcon/assets';
+
+export const title = 'Who are the most active people?';
+export const description = 'Who are the most active people?';
+export const image = LEADERBOARD_IMAGE;

--- a/ui/src/containers/Visualisations/TemplateMostPopularActivities/Card.js
+++ b/ui/src/containers/Visualisations/TemplateMostPopularActivities/Card.js
@@ -24,4 +24,4 @@ Card.propTypes = {
   saveModel: PropTypes.func.isRequired,
 };
 
- export default React.memo(Card);
+export default React.memo(Card);

--- a/ui/src/containers/Visualisations/TemplateMostPopularActivities/Card.js
+++ b/ui/src/containers/Visualisations/TemplateMostPopularActivities/Card.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Map } from 'immutable';
-import { TEMPLATE_MOST_POPULAR_ACTIVITIES } from 'lib/constants/visualise';
-import { LEADERBOARD_IMAGE } from 'ui/components/VisualiseIcon/assets';
-import { LAST_2_MONTHS } from 'ui/utils/constants';
 import TemplateCard from '../components/TemplateCard';
+import buildModel from './buildModel';
+import { title, image } from './constants';
 
 /**
  * @param {immutable.Map} props.model
@@ -15,17 +14,9 @@ const Card = ({
   saveModel,
 }) => (
   <TemplateCard
-    title="What are the most popular activities?"
-    srcImage={LEADERBOARD_IMAGE}
-    onClick={() => {
-      saveModel({
-        attrs: model
-          .set('type', TEMPLATE_MOST_POPULAR_ACTIVITIES)
-          .set('description', 'What are the most popular activities?')
-          .set('previewPeriod', LAST_2_MONTHS)
-          .set('axesgroup', new Map({ optionKey: 'activities', searchString: 'Activity' })),
-      });
-    }} />
+    title={title}
+    srcImage={image}
+    onClick={() => saveModel({ attrs: buildModel(model) })} />
 );
 
 Card.propTypes = {
@@ -33,4 +24,4 @@ Card.propTypes = {
   saveModel: PropTypes.func.isRequired,
 };
 
-export default React.memo(Card);
+ export default React.memo(Card);

--- a/ui/src/containers/Visualisations/TemplateMostPopularActivities/buildModel.js
+++ b/ui/src/containers/Visualisations/TemplateMostPopularActivities/buildModel.js
@@ -1,0 +1,21 @@
+import { Map } from 'immutable';
+import { TEMPLATE_MOST_POPULAR_ACTIVITIES } from 'lib/constants/visualise';
+import { LAST_2_MONTHS } from 'ui/utils/constants';
+import { description } from './constants';
+
+/**
+ * @param {immutable.Map} model
+ * @returns {immutable.Map}
+ */
+const buildModel = model =>
+  model
+    .set('type', TEMPLATE_MOST_POPULAR_ACTIVITIES)
+    .set('description', description)
+    .set('axesgroup', new Map({ optionKey: 'activities', searchString: 'Activity' }))
+    .set('axesoperator', 'uniqueCount')
+    .set('axesvalue', new Map({ optionKey: 'statements', searchString: 'Statements' }))
+    .set('axesxLabel', 'Statements')
+    .set('axesyLabel', 'Activity')
+    .set('previewPeriod', LAST_2_MONTHS);
+
+export default buildModel;

--- a/ui/src/containers/Visualisations/TemplateMostPopularActivities/constants.js
+++ b/ui/src/containers/Visualisations/TemplateMostPopularActivities/constants.js
@@ -1,0 +1,5 @@
+import { LEADERBOARD_IMAGE } from 'ui/components/VisualiseIcon/assets';
+
+export const title = 'What are the most popular activities?';
+export const description = 'What are the most popular activities?';
+export const image = LEADERBOARD_IMAGE;

--- a/ui/src/containers/Visualisations/TemplateMostPopularVerbs/Card.js
+++ b/ui/src/containers/Visualisations/TemplateMostPopularVerbs/Card.js
@@ -24,4 +24,4 @@ Card.propTypes = {
   saveModel: PropTypes.func.isRequired,
 };
 
- export default React.memo(Card);
+export default React.memo(Card);

--- a/ui/src/containers/Visualisations/TemplateMostPopularVerbs/Card.js
+++ b/ui/src/containers/Visualisations/TemplateMostPopularVerbs/Card.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Map } from 'immutable';
-import { TEMPLATE_MOST_POPULAR_VERBS } from 'lib/constants/visualise';
-import { LEADERBOARD_IMAGE } from 'ui/components/VisualiseIcon/assets';
-import { LAST_2_MONTHS } from 'ui/utils/constants';
 import TemplateCard from '../components/TemplateCard';
+import buildModel from './buildModel';
+import { title, image } from './constants';
 
 /**
  * @param {immutable.Map} props.model
@@ -15,17 +14,9 @@ const Card = ({
   saveModel,
 }) => (
   <TemplateCard
-    title="What are the most popular verbs?"
-    srcImage={LEADERBOARD_IMAGE}
-    onClick={() => {
-      saveModel({
-        attrs: model
-          .set('type', TEMPLATE_MOST_POPULAR_VERBS)
-          .set('description', 'What are the most popular verbs?')
-          .set('previewPeriod', LAST_2_MONTHS)
-          .set('axesgroup', new Map({ optionKey: 'verb', searchString: 'Verb' })),
-      });
-    }} />
+    title={title}
+    srcImage={image}
+    onClick={() => saveModel({ attrs: buildModel(model) })} />
 );
 
 Card.propTypes = {
@@ -33,4 +24,4 @@ Card.propTypes = {
   saveModel: PropTypes.func.isRequired,
 };
 
-export default React.memo(Card);
+ export default React.memo(Card);

--- a/ui/src/containers/Visualisations/TemplateMostPopularVerbs/buildModel.js
+++ b/ui/src/containers/Visualisations/TemplateMostPopularVerbs/buildModel.js
@@ -1,0 +1,21 @@
+import { Map } from 'immutable';
+import { TEMPLATE_MOST_POPULAR_VERBS } from 'lib/constants/visualise';
+import { LAST_2_MONTHS } from 'ui/utils/constants';
+import { description } from './constants';
+
+/**
+ * @param {immutable.Map} model
+ * @returns {immutable.Map}
+ */
+const buildModel = model =>
+  model
+    .set('type', TEMPLATE_MOST_POPULAR_VERBS)
+    .set('description', description)
+    .set('axesgroup', new Map({ optionKey: 'verb', searchString: 'Verb' }))
+    .set('axesoperator', 'uniqueCount')
+    .set('axesvalue', new Map({ optionKey: 'statements', searchString: 'Statements' }))
+    .set('axesxLabel', 'Statements')
+    .set('axesyLabel', 'Verb')
+    .set('previewPeriod', LAST_2_MONTHS);
+
+export default buildModel;

--- a/ui/src/containers/Visualisations/TemplateMostPopularVerbs/constants.js
+++ b/ui/src/containers/Visualisations/TemplateMostPopularVerbs/constants.js
@@ -1,0 +1,5 @@
+import { LEADERBOARD_IMAGE } from 'ui/components/VisualiseIcon/assets';
+
+export const title = 'What are the most popular verbs?';
+export const description = 'What are the most popular verbs?';
+export const image = LEADERBOARD_IMAGE;

--- a/ui/src/containers/Visualisations/TemplateWeekdaysActivity/Card.js
+++ b/ui/src/containers/Visualisations/TemplateWeekdaysActivity/Card.js
@@ -24,4 +24,4 @@ Card.propTypes = {
   saveModel: PropTypes.func.isRequired,
 };
 
- export default React.memo(Card);
+export default React.memo(Card);

--- a/ui/src/containers/Visualisations/TemplateWeekdaysActivity/Card.js
+++ b/ui/src/containers/Visualisations/TemplateWeekdaysActivity/Card.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Map } from 'immutable';
-import { TEMPLATE_WEEKDAYS_ACTIVITY } from 'lib/constants/visualise';
-import { STATEMENTS_IMAGE } from 'ui/components/VisualiseIcon/assets';
 import TemplateCard from '../components/TemplateCard';
+import buildModel from './buildModel';
+import { title, image } from './constants';
 
 /**
  * @param {immutable.Map} props.model
@@ -14,16 +14,9 @@ const Card = ({
   saveModel,
 }) => (
   <TemplateCard
-    title="How does activity change in a week?"
-    srcImage={STATEMENTS_IMAGE}
-    onClick={() => {
-      saveModel({
-        attrs: model
-          .set('type', TEMPLATE_WEEKDAYS_ACTIVITY)
-          .set('description', 'How does activity change in a week?')
-          .set('axesgroup', new Map({ optionKey: 'weekday', searchString: 'Day' })),
-      });
-    }} />
+    title={title}
+    srcImage={image}
+    onClick={() => saveModel({ attrs: buildModel(model) })} />
 );
 
 Card.propTypes = {
@@ -31,4 +24,4 @@ Card.propTypes = {
   saveModel: PropTypes.func.isRequired,
 };
 
-export default React.memo(Card);
+ export default React.memo(Card);

--- a/ui/src/containers/Visualisations/TemplateWeekdaysActivity/buildModel.js
+++ b/ui/src/containers/Visualisations/TemplateWeekdaysActivity/buildModel.js
@@ -1,0 +1,21 @@
+import { Map } from 'immutable';
+import { TEMPLATE_WEEKDAYS_ACTIVITY } from 'lib/constants/visualise';
+import { LAST_7_DAYS } from 'ui/utils/constants';
+import { description } from './constants';
+
+/**
+ * @param {immutable.Map} model
+ * @returns {immutable.Map}
+ */
+const buildModel = model =>
+  model
+    .set('type', TEMPLATE_WEEKDAYS_ACTIVITY)
+    .set('description', description)
+    .set('axesgroup', new Map({ optionKey: 'weekday', searchString: 'Day' }))
+    .set('axesoperator', 'uniqueCount')
+    .set('axesvalue', new Map({ optionKey: 'statements', searchString: 'Statements' }))
+    .set('axesxLabel', 'Day')
+    .set('axesyLabel', 'Statements')
+    .set('previewPeriod', LAST_7_DAYS);
+
+export default buildModel;

--- a/ui/src/containers/Visualisations/TemplateWeekdaysActivity/constants.js
+++ b/ui/src/containers/Visualisations/TemplateWeekdaysActivity/constants.js
@@ -1,0 +1,5 @@
+import { STATEMENTS_IMAGE } from 'ui/components/VisualiseIcon/assets';
+
+export const title = 'How does activity change in a week?';
+export const description = 'How does activity change in a week?';
+export const image = STATEMENTS_IMAGE;

--- a/ui/src/redux/modules/dashboard/gettingStarted.js
+++ b/ui/src/redux/modules/dashboard/gettingStarted.js
@@ -2,14 +2,13 @@ import { Map } from 'immutable';
 import { actions as routerActions } from 'redux-router5';
 import { put, call, takeEvery } from 'redux-saga/effects';
 import {
-  TEMPLATE_MOST_POPULAR_VERBS,
   TEMPLATE_WEEKDAYS_ACTIVITY,
 } from 'lib/constants/visualise';
-import { LAST_2_MONTHS } from 'ui/utils/constants';
 import buildTemplateLast7DaysStatements from 'ui/containers/Visualisations/TemplateLast7DaysStatements/buildModel';
 import buildTemplateActivityOverTime from 'ui/containers/Visualisations/TemplateActivityOverTime/buildModel';
 import buildTemplateMostActivePeople from 'ui/containers/Visualisations/TemplateMostActivePeople/buildModel';
 import buildTemplateMostPopularActivities from 'ui/containers/Visualisations/TemplateMostPopularActivities/buildModel';
+import buildTemplateMostPopularVerbs from 'ui/containers/Visualisations/TemplateMostPopularVerbs/buildModel';
 import { addModel } from '../models';
 
 export const CREATE_GETTING_STARTED = 'learninglocker/dashboard/CREATE_GETTING_STARTED';
@@ -33,13 +32,7 @@ const createVisualisations = async ({ dispatch, userId }) => {
     })),
     dispatch(addModel({
       schema: 'visualisation',
-      props: {
-        description: 'What are the most popular verbs?',
-        type: TEMPLATE_MOST_POPULAR_VERBS,
-        previewPeriod: LAST_2_MONTHS,
-        axesgroup: new Map({ optionKey: 'verb', searchString: 'Verb' }),
-        owner: userId,
-      },
+      props: buildTemplateMostPopularVerbs(new Map({ owner: userId })),
       isExpanded: false,
     })),
     dispatch(addModel({

--- a/ui/src/redux/modules/dashboard/gettingStarted.js
+++ b/ui/src/redux/modules/dashboard/gettingStarted.js
@@ -2,7 +2,6 @@ import { Map } from 'immutable';
 import { actions as routerActions } from 'redux-router5';
 import { put, call, takeEvery } from 'redux-saga/effects';
 import {
-  TEMPLATE_MOST_POPULAR_ACTIVITIES,
   TEMPLATE_MOST_POPULAR_VERBS,
   TEMPLATE_WEEKDAYS_ACTIVITY,
 } from 'lib/constants/visualise';
@@ -10,6 +9,7 @@ import { LAST_2_MONTHS } from 'ui/utils/constants';
 import buildTemplateLast7DaysStatements from 'ui/containers/Visualisations/TemplateLast7DaysStatements/buildModel';
 import buildTemplateActivityOverTime from 'ui/containers/Visualisations/TemplateActivityOverTime/buildModel';
 import buildTemplateMostActivePeople from 'ui/containers/Visualisations/TemplateMostActivePeople/buildModel';
+import buildTemplateMostPopularActivities from 'ui/containers/Visualisations/TemplateMostPopularActivities/buildModel';
 import { addModel } from '../models';
 
 export const CREATE_GETTING_STARTED = 'learninglocker/dashboard/CREATE_GETTING_STARTED';
@@ -44,13 +44,7 @@ const createVisualisations = async ({ dispatch, userId }) => {
     })),
     dispatch(addModel({
       schema: 'visualisation',
-      props: {
-        description: 'What are the most popular activities?',
-        type: TEMPLATE_MOST_POPULAR_ACTIVITIES,
-        previewPeriod: LAST_2_MONTHS,
-        axesgroup: new Map({ optionKey: 'activities', searchString: 'Activity' }),
-        owner: userId,
-      },
+      props: buildTemplateMostPopularActivities(new Map({ owner: userId })),
       isExpanded: false,
     })),
     dispatch(addModel({

--- a/ui/src/redux/modules/dashboard/gettingStarted.js
+++ b/ui/src/redux/modules/dashboard/gettingStarted.js
@@ -2,13 +2,13 @@ import { Map } from 'immutable';
 import { actions as routerActions } from 'redux-router5';
 import { put, call, takeEvery } from 'redux-saga/effects';
 import {
-  TEMPLATE_LAST_7_DAYS_STATEMENTS,
   TEMPLATE_MOST_ACTIVE_PEOPLE,
   TEMPLATE_MOST_POPULAR_ACTIVITIES,
   TEMPLATE_MOST_POPULAR_VERBS,
   TEMPLATE_WEEKDAYS_ACTIVITY,
 } from 'lib/constants/visualise';
 import { LAST_2_MONTHS } from 'ui/utils/constants';
+import buildTemplateLast7DaysStatements from 'ui/containers/Visualisations/TemplateLast7DaysStatements/buildModel';
 import buildTemplateActivityOverTime from 'ui/containers/Visualisations/TemplateActivityOverTime/buildModel';
 import { addModel } from '../models';
 
@@ -23,11 +23,7 @@ const createVisualisations = async ({ dispatch, userId }) => {
   const results = await Promise.all([
     dispatch(addModel({
       schema: 'visualisation',
-      props: {
-        description: 'How many statements have been stored in the last 7 days?',
-        type: TEMPLATE_LAST_7_DAYS_STATEMENTS,
-        owner: userId,
-      },
+      props: buildTemplateLast7DaysStatements(new Map({ owner: userId })),
       isExpanded: false,
     })),
     dispatch(addModel({

--- a/ui/src/redux/modules/dashboard/gettingStarted.js
+++ b/ui/src/redux/modules/dashboard/gettingStarted.js
@@ -2,7 +2,6 @@ import { Map } from 'immutable';
 import { actions as routerActions } from 'redux-router5';
 import { put, call, takeEvery } from 'redux-saga/effects';
 import {
-  TEMPLATE_MOST_ACTIVE_PEOPLE,
   TEMPLATE_MOST_POPULAR_ACTIVITIES,
   TEMPLATE_MOST_POPULAR_VERBS,
   TEMPLATE_WEEKDAYS_ACTIVITY,
@@ -10,6 +9,7 @@ import {
 import { LAST_2_MONTHS } from 'ui/utils/constants';
 import buildTemplateLast7DaysStatements from 'ui/containers/Visualisations/TemplateLast7DaysStatements/buildModel';
 import buildTemplateActivityOverTime from 'ui/containers/Visualisations/TemplateActivityOverTime/buildModel';
+import buildTemplateMostActivePeople from 'ui/containers/Visualisations/TemplateMostActivePeople/buildModel';
 import { addModel } from '../models';
 
 export const CREATE_GETTING_STARTED = 'learninglocker/dashboard/CREATE_GETTING_STARTED';
@@ -55,13 +55,7 @@ const createVisualisations = async ({ dispatch, userId }) => {
     })),
     dispatch(addModel({
       schema: 'visualisation',
-      props: {
-        description: 'Who are the most active people?',
-        type: TEMPLATE_MOST_ACTIVE_PEOPLE,
-        previewPeriod: LAST_2_MONTHS,
-        axesgroup: new Map({ optionKey: 'people', searchString: 'Person' }),
-        owner: userId,
-      },
+      props: buildTemplateMostActivePeople(new Map({ owner: userId })),
       isExpanded: false,
     })),
     dispatch(addModel({

--- a/ui/src/redux/modules/dashboard/gettingStarted.js
+++ b/ui/src/redux/modules/dashboard/gettingStarted.js
@@ -1,14 +1,12 @@
 import { Map } from 'immutable';
 import { actions as routerActions } from 'redux-router5';
 import { put, call, takeEvery } from 'redux-saga/effects';
-import {
-  TEMPLATE_WEEKDAYS_ACTIVITY,
-} from 'lib/constants/visualise';
 import buildTemplateLast7DaysStatements from 'ui/containers/Visualisations/TemplateLast7DaysStatements/buildModel';
 import buildTemplateActivityOverTime from 'ui/containers/Visualisations/TemplateActivityOverTime/buildModel';
 import buildTemplateMostActivePeople from 'ui/containers/Visualisations/TemplateMostActivePeople/buildModel';
 import buildTemplateMostPopularActivities from 'ui/containers/Visualisations/TemplateMostPopularActivities/buildModel';
 import buildTemplateMostPopularVerbs from 'ui/containers/Visualisations/TemplateMostPopularVerbs/buildModel';
+import buildTemplateWeekdaysActivity from 'ui/containers/Visualisations/TemplateWeekdaysActivity/buildModel';
 import { addModel } from '../models';
 
 export const CREATE_GETTING_STARTED = 'learninglocker/dashboard/CREATE_GETTING_STARTED';
@@ -47,12 +45,7 @@ const createVisualisations = async ({ dispatch, userId }) => {
     })),
     dispatch(addModel({
       schema: 'visualisation',
-      props: {
-        description: 'How does activity change in a week?',
-        type: TEMPLATE_WEEKDAYS_ACTIVITY,
-        axesgroup: new Map({ optionKey: 'weekday', searchString: 'Day' }),
-        owner: userId,
-      },
+      props: buildTemplateWeekdaysActivity(new Map({ owner: userId })),
       isExpanded: false,
     })),
   ]);

--- a/ui/src/redux/modules/dashboard/gettingStarted.js
+++ b/ui/src/redux/modules/dashboard/gettingStarted.js
@@ -2,7 +2,6 @@ import { Map } from 'immutable';
 import { actions as routerActions } from 'redux-router5';
 import { put, call, takeEvery } from 'redux-saga/effects';
 import {
-  TEMPLATE_ACTIVITY_OVER_TIME,
   TEMPLATE_LAST_7_DAYS_STATEMENTS,
   TEMPLATE_MOST_ACTIVE_PEOPLE,
   TEMPLATE_MOST_POPULAR_ACTIVITIES,
@@ -10,6 +9,7 @@ import {
   TEMPLATE_WEEKDAYS_ACTIVITY,
 } from 'lib/constants/visualise';
 import { LAST_2_MONTHS } from 'ui/utils/constants';
+import buildTemplateActivityOverTime from 'ui/containers/Visualisations/TemplateActivityOverTime/buildModel';
 import { addModel } from '../models';
 
 export const CREATE_GETTING_STARTED = 'learninglocker/dashboard/CREATE_GETTING_STARTED';
@@ -32,12 +32,7 @@ const createVisualisations = async ({ dispatch, userId }) => {
     })),
     dispatch(addModel({
       schema: 'visualisation',
-      props: {
-        description: 'How has activity changed over time?',
-        type: TEMPLATE_ACTIVITY_OVER_TIME,
-        previewPeriod: LAST_2_MONTHS,
-        owner: userId,
-      },
+      props: buildTemplateActivityOverTime(new Map({ owner: userId })),
       isExpanded: false,
     })),
     dispatch(addModel({


### PR DESCRIPTION
The functions building template visualisation model are duplicated in Visualisations/*/Card.js and Dashboard GettingStarted template. I add Visualisations/*/buildModel.js and share with both Card.js and GettingStarted.

I put visualisation description, card title, and image source are put in Visualisations/*/constants.js