### PR TITLE
fix: Metadata displays URLs with &46; instead of . in source view [LLC-25]

### DIFF
--- a/ui/src/pages/DataSourcePage/StatementForm.js
+++ b/ui/src/pages/DataSourcePage/StatementForm.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Map } from 'immutable';
+import decodeDot from 'lib/helpers/decodeDot';
 
 class StatementForm extends Component {
 
@@ -17,7 +18,7 @@ class StatementForm extends Component {
 
     return (
       <pre>
-        {JSON.stringify(model.toJS(), null, 2)}
+        {decodeDot(JSON.stringify(model.toJS(), null, 2))}
       </pre>
     );
   }


### PR DESCRIPTION
## Which issue does this close?
Closes [LLC-25](https://learningpool.atlassian.net/browse/LLC-25)
