### PR TITLE
Updated @google-cloud/pubsub to version 0.32.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@azure/service-bus": "^1.0.2",
     "@azure/storage-blob": "^10.3.0",
-    "@google-cloud/pubsub": "^0.16.1",
+    "@google-cloud/pubsub": "^0.32.1",
     "@google-cloud/storage": "^1.5.2",
     "@learninglocker/persona-service": "^1.7.1",
     "@learninglocker/xapi-statements": "^7.5.0",


### PR DESCRIPTION
I'm not sure what the problem is but gRPC doesn't build in Ubuntu version 18.04 and 20.04 unless pubsub is updated to version 0.32.1. Version 0.32.1 is the latest version without breaking updates so I don't think it should have any major effect for other Ubuntu versions. 