### PR TITLE
Update "@google-cloud/pubsub": to version 0.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@azure/service-bus": "^1.0.2",
     "@azure/storage-blob": "^10.3.0",
-    "@google-cloud/pubsub": "^0.16.1",
+    "@google-cloud/pubsub": "^0.19.1",
     "@google-cloud/storage": "^1.5.2",
     "@learninglocker/persona-service": "^1.7.1",
     "@learninglocker/xapi-statements": "^7.5.0",


### PR DESCRIPTION
Couldn't compile on Ubuntu 20.04 unless version was bumped up because prebuilt binaries weren't available for gRPC. Version 0.19.1 is the latest version without breaking changes.