### PR TITLE
Fix statement forwarding

### DIFF
--- a/worker/src/handlers/statement/listenForRedisPublish.js
+++ b/worker/src/handlers/statement/listenForRedisPublish.js
@@ -33,7 +33,7 @@ export default () => {
             latestResult = payload;
             if (payload) {
               logger.debug(`Popped '${pubKey}':`, payload);
-              Statement.findOne({ 'statement.id': payload }, (err, statement) => {
+              Statement.findOne({ 'statement.id': JSON.parse(payload).statementId }, (err, statement) => {
                 // get the statement so that we can find its database id
                 // push it straight into the correct queues
                 statementHandler({ statementId: statement._id });


### PR DESCRIPTION

#### Which issue does this close?
Closes #1580 
Closes #1576 
Closes #1574 

#### Describe your changes providing screenshots of UI changes if necessary.
Fixes the statement forwarding logic. The payload now contains `{"statementId":"0e4f1541-321c-4b60-b294-dde1cc6f9f87","organisationId":"603fd8e4fce8e30141294682"}` which you need to only query on the statement ID.