### PR TITLE
chore(lab): migration lab baseline and compatibility freeze

### DIFF
--- a/docs/adr/0001-modernize-via-strangler-keep-mongo.md
+++ b/docs/adr/0001-modernize-via-strangler-keep-mongo.md
@@ -1,0 +1,40 @@
+# ADR 0001: Modernize via strangler, keep Mongo
+
+## Status
+
+Accepted
+
+## Context
+
+Learning Locker 2 is a management/analytics layer over MongoDB and Redis. The xAPI HTTP surface lives in a separate service (`LearningLocker/xapi-service`). Statement documents, aggregation pipelines, auth scopes, Redis notify channels, and queue names form a hard compatibility boundary.
+
+A Rails/Postgres rewrite would force a second migration of document shape, indexes, void/hash semantics, and aggregation APIs. That conflicts with the goal of a modern core LRS with minimum risk.
+
+## Decision
+
+1. Modernize this fork with a strangler approach on Node.js LTS + TypeScript.
+2. Keep MongoDB as the system of record for statements and related LRS data.
+3. Keep Redis contracts for notify/cache/queues until dual-run parity exists.
+4. Treat `xapi-service` as part of the same compatibility unit.
+5. Use two lab VMs (`ll-legacy`, `ll-modern`) for differential testing before production cutover.
+6. Do not put xAPI statements into Postgres as a first step.
+
+## Consequences
+
+### Positive
+
+- Existing statement documents remain readable without a shape migration.
+- Contract tests and golden paths can compare legacy vs modern behavior.
+- Risk is localized to process boundaries (worker, API, shared kernel).
+
+### Negative
+
+- Temporary dual-stack operational cost (two VMs, two runtimes).
+- `@learninglocker/*` packages likely need vendoring/forking for modern Node.
+- Full UI rewrite remains deferred and can lag behind API/worker.
+
+## Alternatives considered
+
+- Rails + Postgres LRS rewrite — rejected due to aggregation and data-preservation risk.
+- Rails + Mongoid façade — acceptable only if Ruby is an organizational constraint; not chosen.
+- Big-bang rewrite of API + worker + UI + xAPI — rejected as highest regression risk.

--- a/docs/contracts/compatibility-freeze.md
+++ b/docs/contracts/compatibility-freeze.md
@@ -1,0 +1,55 @@
+# Compatibility freeze (lab baseline)
+
+Do not change these contracts without dual-run parity between `ll-legacy` and `ll-modern`.
+
+## Mongo collections / shape
+
+Primary models under `lib/models/`:
+
+- `statements` — nested `statement`, `organisation`, `lrs_id`, `client`, persona fields, queue markers, forwarding state, `hash`, `metadata`
+- `lrs`, `client`, `organisation`, `user`, `role`
+- persona-related collections via `@learninglocker/persona-service`
+- `querybuildercache`, `querybuildercachevalue`, `statementForwarding`, `export`, `download`, `batchDelete`
+
+Indexes from historical v2 migrations remain authoritative, especially:
+
+- unique `{organisation, lrs_id, hash}`
+- timestamp/stored cursor indexes
+- actor/verb/object and persona identifier paths
+
+## Redis
+
+- Prefix: `REDIS_PREFIX` (lab default `LEARNINGLOCKER`)
+- Statement notify channel/list used by worker listeners
+- Aggregation cache keys and TTLs from `.env.example`
+
+## Queues
+
+Names in `lib/constants/statements.js` are durable contracts, including historical typos.
+
+Required for core post-ingest path:
+
+- `STATEMENT_QUEUE`
+- `STATEMENT_PERSON_QUEUE` (`STATEMENT_EXTRACT_PERSONAS_QUEUE`)
+- `STATEMENT_QUERYBUILDERCACHE_QUEUE`
+- forwarding queues when enabled
+
+## Auth / API
+
+- Passport strategies and JWT shapes in `api/src/auth/`
+- Scope filters in `lib/services/auth/`
+- `/v2` REST surface and statement aggregate/count routes in `api/src/routes/HttpRoutes.js`
+
+## xAPI peer
+
+- HTTP xAPI is served by `xapi-service`, not this app process
+- Shared Mongo DB name and Redis must match Learning Locker
+- Lab uses Express port `8081` for xAPI, `8080` for LL API, `3000` for UI
+
+## Golden path
+
+1. Authenticated client stores a statement through xAPI
+2. Document appears in Mongo with expected envelope fields
+3. Redis notify triggers worker
+4. Persona extract and query-builder cache complete
+5. Aggregate/count APIs return scoped results

--- a/lab/.gitattributes
+++ b/lab/.gitattributes
@@ -1,0 +1,3 @@
+*.sh text eol=lf
+lab/**/*.yml text eol=lf
+docs/**/*.md text eol=lf

--- a/lab/.gitignore
+++ b/lab/.gitignore
@@ -1,0 +1,10 @@
+# Local lab secrets and generated env files
+.env
+.env.*
+!.env.example
+!**/.env.example
+!**/*.env.overlay
+
+# OS / editor
+.DS_Store
+Thumbs.db

--- a/lab/README.md
+++ b/lab/README.md
@@ -1,0 +1,62 @@
+# Learning Locker migration lab
+
+Two libvirt VMs on `home-server` (`192.168.168.110`) for strangler modernization and differential testing.
+
+## Hosts
+
+| Alias | IP | Role | Baseline runtime |
+|---|---|---|---|
+| `ll-legacy` | `192.168.122.110` | Behavior oracle | Node 10 (container), Mongo 4.2 RS, Redis 4 |
+| `ll-modern` | `192.168.122.111` | Migration target | Node 20 LTS, Mongo 7 RS, Redis 7 |
+
+SSH from the Windows workstation:
+
+```bash
+ssh ll-legacy
+ssh ll-modern
+```
+
+Both jump via `home-server` using `~/.ssh/laptop_key`.
+
+## Layout on each VM
+
+```text
+/opt/learninglocker/
+  app/                 # this fork
+  xapi-service/        # LearningLocker/xapi-service
+  infra/               # compose + helper scripts synced from lab/
+```
+
+## Start infrastructure
+
+```bash
+cd /opt/learninglocker/infra
+sudo docker compose -p ll up -d
+./init-replica.sh
+```
+
+## Application env
+
+Copy templates, never commit real secrets:
+
+```bash
+cp /opt/learninglocker/app/.env.example /opt/learninglocker/app/.env
+cp /opt/learninglocker/xapi-service/.env.example /opt/learninglocker/xapi-service/.env
+# then apply lab overlays from lab/env/*.env.overlay
+```
+
+Generate `APP_SECRET` locally:
+
+```bash
+openssl rand -hex 32
+```
+
+## Host firewall note
+
+`virbr0` NAT for the lab is applied by `/usr/local/sbin/ll-lab-nft.sh` and `ll-lab-nft.service` on `home-server`.
+
+## Safety
+
+- Do not modify existing host VMs (`omr-client`, `Haiku`) or production data.
+- Use synthetic fixtures only until parity reports are green.
+- Keep compatibility freeze in `docs/contracts/compatibility-freeze.md`.

--- a/lab/README.md
+++ b/lab/README.md
@@ -27,13 +27,18 @@ Both jump via `home-server` using `~/.ssh/laptop_key`.
   infra/               # compose + helper scripts synced from lab/
 ```
 
-## Start infrastructure
+## Bootstrap
 
 ```bash
-cd /opt/learninglocker/infra
-sudo docker compose -p ll up -d
-./init-replica.sh
+cd /opt/learninglocker/app
+git checkout chore/lab-baseline-infra
+STACK=legacy sudo -E bash lab/scripts/bootstrap-vm.sh   # on ll-legacy
+STACK=modern sudo -E bash lab/scripts/bootstrap-vm.sh   # on ll-modern
+STACK=legacy bash lab/scripts/install-node.sh
+STACK=modern bash lab/scripts/install-node.sh
 ```
+
+Legacy app commands run through `ll-node10-exec` because Ubuntu 24.04 cannot host Node 10 natively.
 
 ## Application env
 

--- a/lab/env/app.env.overlay
+++ b/lab/env/app.env.overlay
@@ -1,0 +1,25 @@
+# Lab overlay for Learning Locker app (.env)
+# Apply on top of .env.example. Do not commit real APP_SECRET values.
+
+NODE_ENV=development
+SITE_URL=http://127.0.0.1:3000
+UI_PORT=3000
+UI_HOST=127.0.0.1
+API_PORT=8080
+API_HOST=127.0.0.1
+
+# Fill per host with: openssl rand -hex 32
+APP_SECRET=REPLACE_ME
+
+MONGODB_PATH=mongodb://127.0.0.1:27017/learninglocker_v2?replicaSet=rs0
+MONGODB_TEST_PATH=mongodb://127.0.0.1:27017/llv2tests?replicaSet=rs0
+
+REDIS_URL=redis://127.0.0.1:6379/0
+REDIS_PREFIX=LEARNINGLOCKER
+QUEUE_PROVIDER=REDIS
+QUEUE_NAMESPACE=LAB
+
+FS_REPO=local
+GOOGLE_ENABLED=false
+LOG_MIN_LEVEL=info
+COLOR_LOGS=true

--- a/lab/env/xapi.env.overlay
+++ b/lab/env/xapi.env.overlay
@@ -1,0 +1,13 @@
+# Lab overlay for xapi-service (.env)
+# Apply on top of .env.example.
+
+MODELS_REPO=mongo
+MONGO_URL=mongodb://127.0.0.1:27017/learninglocker_v2?replicaSet=rs0
+MONGO_DB=learninglocker_v2
+
+REDIS_PREFIX=LEARNINGLOCKER
+REDIS_URL=redis://127.0.0.1:6379/0
+
+EXPRESS_PORT=8081
+STORAGE_REPO=local
+WINSTON_CONSOLE_LEVEL=info

--- a/lab/legacy/docker-compose.yml
+++ b/lab/legacy/docker-compose.yml
@@ -1,0 +1,33 @@
+name: ll
+
+services:
+  mongo:
+    image: mongo:4.2
+    restart: unless-stopped
+    command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
+    ports:
+      - "27017:27017"
+    volumes:
+      - ll_mongo_legacy:/data/db
+    healthcheck:
+      test: ["CMD", "mongo", "--quiet", "--eval", "db.adminCommand('ping').ok"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+
+  redis:
+    image: redis:4
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - ll_redis_legacy:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+
+volumes:
+  ll_mongo_legacy:
+  ll_redis_legacy:

--- a/lab/modern/docker-compose.yml
+++ b/lab/modern/docker-compose.yml
@@ -1,0 +1,33 @@
+name: ll
+
+services:
+  mongo:
+    image: mongo:7
+    restart: unless-stopped
+    command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
+    ports:
+      - "27017:27017"
+    volumes:
+      - ll_mongo_modern:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping').ok"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+
+  redis:
+    image: redis:7
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - ll_redis_modern:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+
+volumes:
+  ll_mongo_modern:
+  ll_redis_modern:

--- a/lab/scripts/apply-env-overlay.sh
+++ b/lab/scripts/apply-env-overlay.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Merge KEY=VALUE overlays into a target .env without printing secrets.
+# Usage: ./apply-env-overlay.sh <target.env> <overlay.env>
+
+target="${1:?target env required}"
+overlay="${2:?overlay env required}"
+
+tmp="$(mktemp)"
+cp "${target}" "${tmp}"
+
+while IFS= read -r line || [[ -n "${line}" ]]; do
+  [[ -z "${line}" || "${line}" =~ ^[[:space:]]*# ]] && continue
+  key="${line%%=*}"
+  value="${line#*=}"
+  if grep -qE "^${key}=" "${tmp}"; then
+    # portable in-place replace for first matching key
+    awk -v k="${key}" -v v="${value}" '
+      BEGIN { FS=OFS="=" }
+      $1==k && !done { print k"="v; done=1; next }
+      { print }
+      END { if (!done) print k"="v }
+    ' "${tmp}" > "${tmp}.new"
+    mv "${tmp}.new" "${tmp}"
+  else
+    printf '%s=%s\n' "${key}" "${value}" >> "${tmp}"
+  fi
+done < "${overlay}"
+
+mv "${tmp}" "${target}"
+echo "Applied overlay to ${target}"

--- a/lab/scripts/bootstrap-vm.sh
+++ b/lab/scripts/bootstrap-vm.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bootstrap one lab VM after the repo is cloned to /opt/learninglocker/app
+# Usage: STACK=legacy|modern ./bootstrap-vm.sh
+
+STACK="${STACK:?STACK=legacy|modern required}"
+ROOT=/opt/learninglocker
+APP="${ROOT}/app"
+XAPI="${ROOT}/xapi-service"
+INFRA="${ROOT}/infra"
+
+mkdir -p "${INFRA}"
+rsync -a --delete "${APP}/lab/${STACK}/" "${INFRA}/"
+cp "${APP}/lab/scripts/"*.sh "${INFRA}/"
+chmod +x "${INFRA}/"*.sh
+
+cd "${INFRA}"
+docker compose -p ll down --remove-orphans || true
+docker compose -p ll up -d
+./init-replica.sh
+
+if [[ ! -f "${APP}/.env" ]]; then
+  cp "${APP}/.env.example" "${APP}/.env"
+fi
+if [[ ! -f "${XAPI}/.env" ]]; then
+  cp "${XAPI}/.env.example" "${XAPI}/.env"
+fi
+
+./apply-env-overlay.sh "${APP}/.env" "${APP}/lab/env/app.env.overlay"
+./apply-env-overlay.sh "${XAPI}/.env" "${APP}/lab/env/xapi.env.overlay"
+
+if grep -q 'APP_SECRET=REPLACE_ME' "${APP}/.env" || grep -qE '^APP_SECRET=$' "${APP}/.env"; then
+  secret="$(openssl rand -hex 32)"
+  # rewrite only APP_SECRET
+  awk -v s="${secret}" '
+    BEGIN { FS=OFS="=" }
+    $1=="APP_SECRET" { print "APP_SECRET="s; next }
+    { print }
+  ' "${APP}/.env" > "${APP}/.env.tmp"
+  mv "${APP}/.env.tmp" "${APP}/.env"
+  echo "Generated APP_SECRET"
+fi
+
+echo "Bootstrap complete for stack=${STACK}"

--- a/lab/scripts/bootstrap-vm.sh
+++ b/lab/scripts/bootstrap-vm.sh
@@ -15,9 +15,23 @@ rsync -a --delete "${APP}/lab/${STACK}/" "${INFRA}/"
 cp "${APP}/lab/scripts/"*.sh "${INFRA}/"
 chmod +x "${INFRA}/"*.sh
 
+# Stop earlier ad-hoc compose from first-boot experiments.
+if [[ -f /home/ubuntu/docker-compose.yml ]]; then
+  docker compose -f /home/ubuntu/docker-compose.yml -p ubuntu down --remove-orphans || true
+fi
+
 cd "${INFRA}"
 docker compose -p ll down --remove-orphans || true
 docker compose -p ll up -d
+
+# Wait for Mongo before replica init.
+for i in $(seq 1 60); do
+  if docker compose -p ll exec -T mongo bash -lc 'command -v mongosh >/dev/null && mongosh --quiet --eval "db.adminCommand(\"ping\").ok" || mongo --quiet --eval "db.adminCommand(\"ping\").ok"' >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+
 ./init-replica.sh
 
 if [[ ! -f "${APP}/.env" ]]; then

--- a/lab/scripts/init-replica.sh
+++ b/lab/scripts/init-replica.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Idempotent single-node replica set init for lab Mongo.
+# Usage: ./init-replica.sh [mongo|mongosh]
+
+MONGO_CLI="${1:-}"
+if [[ -z "${MONGO_CLI}" ]]; then
+  if docker compose -p ll exec -T mongo mongosh --version >/dev/null 2>&1; then
+    MONGO_CLI=mongosh
+  else
+    MONGO_CLI=mongo
+  fi
+fi
+
+echo "Using CLI: ${MONGO_CLI}"
+
+docker compose -p ll exec -T mongo "${MONGO_CLI}" --quiet --eval '
+try {
+  const s = rs.status();
+  if (s.ok) {
+    print("replica set already initialized: " + s.set);
+    quit(0);
+  }
+} catch (e) {
+  // not initialized yet
+}
+
+const result = rs.initiate({
+  _id: "rs0",
+  members: [{ _id: 0, host: "127.0.0.1:27017" }]
+});
+printjson(result);
+'

--- a/lab/scripts/install-node.sh
+++ b/lab/scripts/install-node.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Node runtime helpers for the lab VM.
+# legacy -> Node 10 via pinned Docker image wrappers
+# modern -> Node 20 via NodeSource
+
+STACK="${STACK:?STACK=legacy|modern required}"
+
+if [[ "${STACK}" == "modern" ]]; then
+  if command -v node >/dev/null 2>&1 && node -v | grep -q '^v20\.'; then
+    echo "Node $(node -v) already installed"
+  else
+    curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
+  fi
+  if ! command -v yarn >/dev/null 2>&1; then
+    sudo npm install -g yarn@1.22.22
+  fi
+  if ! command -v pm2 >/dev/null 2>&1; then
+    sudo npm install -g pm2@5
+  fi
+  node -v
+  yarn -v
+  pm2 -v
+  exit 0
+fi
+
+if [[ "${STACK}" == "legacy" ]]; then
+  sudo docker pull node:10-bullseye
+  sudo tee /usr/local/bin/ll-node10-exec >/dev/null <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+workdir="${PWD}"
+exec sudo docker run --rm \
+  --network host \
+  -v /opt/learninglocker:/opt/learninglocker \
+  -v "${workdir}:${workdir}" \
+  -w "${workdir}" \
+  -e HOME=/tmp \
+  -e npm_config_cache=/tmp/.npm \
+  node:10-bullseye \
+  bash -lc "npm install -g yarn@1.22.19 >/dev/null 2>&1; $*"
+EOF
+  sudo tee /usr/local/bin/ll-node10 >/dev/null <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exec ll-node10-exec "$@"
+EOF
+  sudo chmod +x /usr/local/bin/ll-node10 /usr/local/bin/ll-node10-exec
+  ll-node10-exec 'node -v && yarn -v'
+  echo "Legacy Node 10 helper installed (ll-node10 / ll-node10-exec)"
+  exit 0
+fi
+
+echo "Unknown STACK=${STACK}" >&2
+exit 1


### PR DESCRIPTION
## Summary
- Add ADR for strangler modernization while keeping Mongo
- Freeze Redis/queue/auth/xAPI contracts for dual-run parity
- Add reproducible lab compose (legacy Mongo 4.2 / modern Mongo 7) with replica set, env overlays, and bootstrap/Node helpers

## Test plan
- [x] VMs ll-legacy and ll-modern bootstrapped
- [x] Mongo replica set initialized on both
- [x] App/xAPI env overlays applied with generated APP_SECRET
- [ ] Node helpers installed on both VMs
- [ ] Yarn install + smoke tests on legacy/modern


Made with [Cursor](https://cursor.com)